### PR TITLE
Add preview and placeholder guard for copy button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,11 @@ function App() {
   const [animateCount, setAnimateCount] = useState(false);
   const [isLoadingSchedule, setIsLoadingSchedule] = useState(false);
   const [showCopyFeedbackFor, setShowCopyFeedbackFor] = useState<string | null>(null);
+  const [structuredMode, setStructuredMode] = useState(false);
+  const [freeText, setFreeText] = useState('');
+  const [worldName, setWorldName] = useState('');
+  const [creatorName, setCreatorName] = useState('');
+  const [structuredTemplate, setStructuredTemplate] = useState<string[]>([]);
 
   const instrumentEmojiArray = '🎸 🎹 🥁 🎺 🎻 🎷 🪕 🪗 🎤 🎧 📯 🪘 🎼'.split(' ');
 
@@ -31,6 +36,12 @@ function App() {
     const t = setTimeout(() => setAnimateCount(false), 500);
     return () => clearTimeout(t);
   }, [tweetText]);
+
+  useEffect(() => {
+    if (structuredMode) {
+      setTweetText(buildStructuredTweet(freeText, worldName, creatorName));
+    }
+  }, [freeText, worldName, creatorName, structuredMode]);
 
   // Reference point: Meeting #208 on 2025-02-02
   const referenceDate = new Date('2025-02-02');
@@ -62,6 +73,10 @@ function App() {
         `【場所】ワールド名 By クリエイター名\n` +
         `【参加方法】Group＋「題名のないお茶会」にjoin`;
       setTweetText(template);
+      setFreeText('');
+      setWorldName('');
+      setCreatorName('');
+      setStructuredMode(true);
       setIsLoadingSchedule(false);
     }, 300); // 300ms delay
   };
@@ -73,6 +88,53 @@ function App() {
         setShowCopyFeedbackFor(null);
       }, 1500);
     }).catch(err => console.error('Failed to copy emoji: ', err));
+  };
+
+  const handleTweetCopy = () => {
+    navigator.clipboard.writeText(tweetText).then(() => {
+      setShowCopyFeedbackFor('tweet');
+      setTimeout(() => setShowCopyFeedbackFor(null), 1500);
+    }).catch(err => console.error('Failed to copy text: ', err));
+  };
+
+  const parseStructuredFields = (text: string) => {
+    const free = text.split('\n')[0]?.replace('#あ茶会', '').trim() || '';
+    const locationRegex = /【場所】([^\n]+)\s*By\s*(.+?)(?:\s*$|\n)/i;
+    const locationMatch = text.match(locationRegex);
+    if (!locationMatch) {
+      return null;
+    }
+    return {
+      freeText: free === '自由文' ? '' : free,
+      world: locationMatch[1].trim() === 'ワールド名' ? '' : locationMatch[1].trim(),
+      creator: locationMatch[2].trim() === 'クリエイター名' ? '' : locationMatch[2].trim(),
+    };
+  };
+
+  const switchToStructuredMode = () => {
+    const parsed = parseStructuredFields(tweetText);
+    if (!parsed) {
+      alert('現在のテキストはテンプレートと互換性がないため、構造化編集に戻せません。');
+      return;
+    }
+    setFreeText(parsed.freeText);
+    setWorldName(parsed.world);
+    setCreatorName(parsed.creator);
+    setStructuredTemplate(tweetText.split('\n'));
+    setStructuredMode(true);
+  };
+
+  const buildStructuredTweet = (free: string, world: string, creator: string) => {
+    if (!structuredTemplate.length) return tweetText;
+    const lines = [...structuredTemplate];
+    lines[0] = `${free} #あ茶会`;
+    return lines
+      .map((line) =>
+        line.startsWith('【場所】')
+          ? `【場所】${world} By ${creator}`
+          : line,
+      )
+      .join('\n');
   };
 
   const validateTweet = (text: string) => {
@@ -98,6 +160,9 @@ function App() {
     const locationMatch = text.match(locationRegex);
     const hasValidLocation = locationMatch !== null;
 
+    const placeholdersRegex = /(ワールド名|クリエイター名|自由文)/;
+    const hasPlaceholders = placeholdersRegex.test(text);
+
     if (!dateMatch) {
       return {
         isValid: false,
@@ -108,6 +173,7 @@ function App() {
         isCorrectMeeting: false,
         hasTime: false,
         hasValidLocation: false,
+        hasPlaceholders,
         extractedInfo: {
           date: null,
           time: null,
@@ -137,7 +203,13 @@ function App() {
       : null;
 
     return {
-      isValid: isSunday && hasHashtag && isCorrectMeeting && timeMatch !== null && hasValidLocation,
+      isValid:
+        isSunday &&
+        hasHashtag &&
+        isCorrectMeeting &&
+        timeMatch !== null &&
+        hasValidLocation &&
+        !hasPlaceholders,
       date: tweetDate,
       isSunday,
       hasHashtag,
@@ -146,6 +218,7 @@ function App() {
       isCorrectMeeting,
       hasTime: timeMatch !== null,
       hasValidLocation,
+      hasPlaceholders,
       extractedInfo: {
         date: dateMatch ? `${month}月${day}日(日)` : null,
         time,
@@ -173,20 +246,45 @@ function App() {
           <label htmlFor="tweetTextArea" className="block text-lg font-semibold text-neutral-dark mb-3">
             ツイートテキスト
           </label>
-          <button
-            onClick={generateThisWeeksSchedule}
-            disabled={isLoadingSchedule}
-            className="mb-4 px-6 py-3 bg-brand-primary text-white rounded-lg hover:bg-opacity-85 transition-all duration-150 text-base font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-accent focus:ring-opacity-75 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center w-full sm:w-auto"
-          >
-            {isLoadingSchedule ? (
-              <>
-                <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                生成中...
-              </>
-            ) : (
-              '今週の予定を生成'
-            )}
-          </button>
+          <div className="flex flex-wrap gap-2 mb-4">
+            <button
+              onClick={generateThisWeeksSchedule}
+              disabled={isLoadingSchedule}
+              className="px-6 py-3 bg-brand-primary text-white rounded-lg hover:bg-opacity-85 transition-all duration-150 text-base font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-accent focus:ring-opacity-75 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center"
+            >
+              {isLoadingSchedule ? (
+                <>
+                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                  生成中...
+                </>
+              ) : (
+                '今週の予定を生成'
+              )}
+            </button>
+            <button
+              onClick={structuredMode ? () => setStructuredMode(false) : switchToStructuredMode}
+              className="px-4 py-3 bg-brand-secondary text-white rounded-lg hover:bg-opacity-85 transition-all duration-150 text-base font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-accent"
+            >
+              {structuredMode ? '直接編集へ' : '項目ごとに編集'}
+            </button>
+            <div className="flex flex-col items-center relative">
+              <button
+                onClick={handleTweetCopy}
+                disabled={validation.hasPlaceholders}
+                className="px-4 py-3 bg-neutral-medium text-white rounded-lg hover:bg-opacity-85 transition-all duration-150 text-base font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-accent disabled:opacity-70 disabled:cursor-not-allowed"
+              >
+                全文コピー
+              </button>
+              {showCopyFeedbackFor === 'tweet' && (
+                <span className="absolute -top-7 left-1/2 -translate-x-1/2 text-xs bg-neutral-dark text-white px-2 py-0.5 rounded-md shadow-lg whitespace-nowrap z-10">
+                  Copied!
+                </span>
+              )}
+              {validation.hasPlaceholders && (
+                <span className="mt-1 text-xs text-red-500">プレイスホルダーを埋めてください</span>
+              )}
+            </div>
+          </div>
 
           {/* New Emoji Helper Section */}
           <div className="mb-4">
@@ -214,13 +312,44 @@ function App() {
           <div className="mb-2 text-sm text-right text-neutral-dark"> {/* Adjusted mb */}
              <span className={`font-mono ${animateCount ? 'animate-pulse-fade' : ''}`}>文字数: {charCount}</span>
           </div>
-          <textarea
-            id="tweetTextArea"
-            value={tweetText}
-            onChange={(e) => setTweetText(e.target.value)}
-            className="w-full h-48 p-3 border border-neutral-medium rounded-lg focus:ring-2 focus:ring-brand-accent focus:border-brand-accent bg-white text-neutral-dark text-base shadow-sm" // Adjusted h, p
-            placeholder="ここにツイートを入力してください..."
-          />
+          {structuredMode ? (
+            <div className="space-y-2">
+              <input
+                type="text"
+                value={freeText}
+                onChange={(e) => setFreeText(e.target.value)}
+                className="w-full p-2 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
+                placeholder="自由文"
+              />
+              <input
+                type="text"
+                value={worldName}
+                onChange={(e) => setWorldName(e.target.value)}
+                className="w-full p-2 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
+                placeholder="ワールド名"
+              />
+              <input
+                type="text"
+                value={creatorName}
+                onChange={(e) => setCreatorName(e.target.value)}
+                className="w-full p-2 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
+                placeholder="クリエイター名"
+              />
+              <textarea
+                readOnly
+                value={tweetText}
+                className="w-full h-48 p-3 border border-neutral-medium rounded-lg bg-neutral-ultralight text-neutral-dark text-base shadow-sm"
+              />
+            </div>
+          ) : (
+            <textarea
+              id="tweetTextArea"
+              value={tweetText}
+              onChange={(e) => setTweetText(e.target.value)}
+              className={`w-full h-48 p-3 border rounded-lg focus:ring-2 focus:ring-brand-accent focus:border-brand-accent bg-white text-neutral-dark text-base shadow-sm ${validation.hasPlaceholders ? 'border-red-500' : 'border-neutral-medium'}`}
+              placeholder="ここにツイートを入力してください..."
+            />
+          )}
           <div
             className={`mt-2 text-sm text-right font-medium ${ // Adjusted mt
               tweetLength > maxTweetLength ? 'text-red-500' : 'text-neutral-medium'
@@ -236,11 +365,12 @@ function App() {
             <>
               <h2 className="text-2xl font-bold text-brand-secondary mb-6 text-center">検証結果</h2>
               <div className="space-y-3">
-                {[
+                {[ 
                   { Icon: Calendar, label: "日曜日の日付", isValid: validation.isSunday, dataTestId: "validation-date" },
                   { Icon: Clock, label: "時間が含まれている", isValid: validation.hasTime, dataTestId: "validation-time" },
                   { Icon: MapPin, label: "有効な場所形式が含まれている", isValid: validation.hasValidLocation, dataTestId: "validation-location" },
                   { Icon: Hash, label: "#あ茶会 ハッシュタグが含まれている", isValid: validation.hasHashtag, dataTestId: "validation-hashtag" },
+                  { Icon: Hash, label: "プレイスホルダーが残っていない", isValid: !validation.hasPlaceholders, dataTestId: "validation-placeholder" },
                 ].map(({ Icon, label, isValid, dataTestId }) => (
                   <div key={label} data-testid={dataTestId} className="flex items-center justify-between py-2 border-b border-neutral-medium/30">
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- show tweet preview when editing fields separately
- disable copy button with warning until placeholders are filled

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6843cb8dc6148328adb78582daa425ba