### PR TITLE
Enable multiline free text field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,12 +117,11 @@ function App() {
                 <label htmlFor="freeTextInput" className="block text-sm font-semibold text-neutral-dark mb-1">
                   自由文
                 </label>
-                <input
+                <textarea
                   id="freeTextInput"
-                  type="text"
                   value={freeText}
                   onChange={(e) => setFreeText(e.target.value)}
-                  className="w-full p-2 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
+                  className="w-full p-2 h-24 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
                   placeholder="自由文"
                 />
               </div>

--- a/src/hooks/useTweetState.test.ts
+++ b/src/hooks/useTweetState.test.ts
@@ -16,6 +16,12 @@ describe('parseStructuredFields', () => {
     const result = parseStructuredFields(text);
     expect(result?.instrument).toBe('🥁');
   });
+
+  it('handles multi-line free text', () => {
+    const multi = template.join('\n').replace('自由文', 'line1\nline2');
+    const result = parseStructuredFields(multi);
+    expect(result?.freeText).toBe('line1\nline2');
+  });
 });
 
 describe('buildStructuredTweet', () => {
@@ -24,5 +30,10 @@ describe('buildStructuredTweet', () => {
     expect(result).toContain('第210回 🎹題名のないお茶会');
     expect(result).toContain('【場所】World By Creator');
     expect(result.startsWith('test #あ茶会')).toBe(true);
+  });
+
+  it('supports multi-line free text', () => {
+    const result = buildStructuredTweet(template, 'line1\nline2', 'World', 'Creator', '🎻');
+    expect(result.startsWith('line1\nline2 #あ茶会')).toBe(true);
   });
 });

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -19,7 +19,8 @@ export interface ParsedFields {
 }
 
 export function parseStructuredFields(text: string): ParsedFields | null {
-  const free = text.split('\n')[0]?.replace('#あ茶会', '').trim() || '';
+  const freeMatch = text.match(/^[\s\S]*?(?=#あ茶会)/);
+  const free = freeMatch ? freeMatch[0].trim() : '';
   const locationRegex = /【場所】([^\n]+)\s*By\s*(.+?)(?:\s*$|\n)/i;
   const locationMatch = text.match(locationRegex);
   if (!locationMatch) {


### PR DESCRIPTION
## Summary
- make free text area a multiline textarea
- parse multiline free text correctly
- test multiline free text handling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68450224d1f483289a10c74cfc48aa54