### PR TITLE
Adjust meeting counts after cancellation

### DIFF
--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -103,7 +103,11 @@ export function validateTweet(
   const weeksDiff = Math.round(
     (tweetDate.getTime() - referenceDate.getTime()) / (7 * 24 * 60 * 60 * 1000),
   );
-  const expectedMeetingNumber = referenceMeetingNumber + weeksDiff;
+  let expectedMeetingNumber = referenceMeetingNumber + weeksDiff;
+  const skippedDate = new Date('2025-06-08');
+  if (tweetDate > skippedDate) {
+    expectedMeetingNumber -= 1;
+  }
   const meetingNumber = meetingMatch ? parseInt(meetingMatch[1]) : null;
   const isCorrectMeeting = meetingNumber === expectedMeetingNumber;
   const time = timeMatch
@@ -198,7 +202,11 @@ export function useTweetState() {
         (upcomingSunday.getTime() - referenceDate.getTime()) /
           (7 * 24 * 60 * 60 * 1000),
       );
-      const meetingNumber = referenceMeetingNumber + weeksDiff;
+      let meetingNumber = referenceMeetingNumber + weeksDiff;
+      const skippedDate = new Date('2025-06-08');
+      if (upcomingSunday > skippedDate) {
+        meetingNumber -= 1;
+      }
       const template =
         `自由文 #あ茶会\n\n` +
         `第${meetingNumber}回 ${instrumentEmoji}題名のないお茶会🏘️\n` +


### PR DESCRIPTION
## Summary
- adjust meeting number logic to account for the skipped 2025/06/08 session

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684bdf768a208328a4d3913c15af3cd0