### PR TITLE
Add editable suffix emoji

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ function App() {
     setCreatorName,
     instrumentEmoji,
     setInstrumentEmoji,
+    suffixEmoji,
+    setSuffixEmoji,
     generateThisWeeksSchedule,
     handleEmojiCopy,
     handleTweetCopy,
@@ -86,11 +88,36 @@ function App() {
           <div className="mb-4">
             <span className="text-sm font-semibold text-neutral-dark mb-1">楽器絵文字:</span>
             <div className="flex overflow-x-auto gap-2 py-2 scrollbar-thin scrollbar-thumb-neutral-medium/50 scrollbar-track-neutral-light">
+          {instrumentEmojiArray.map((emoji, index) => (
+            <div key={index} className="relative">
+              <button
+                onClick={() => {
+                  setInstrumentEmoji(emoji);
+                  handleEmojiCopy(emoji);
+                }}
+                className="p-1.5 text-xl bg-white rounded-md shadow-sm hover:bg-neutral-medium/20 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-accent"
+                aria-label={`Select emoji ${emoji}`}
+              >
+                {emoji}
+              </button>
+              {showCopyFeedbackFor === emoji && (
+                <span className="absolute -top-7 left-1/2 -translate-x-1/2 text-xs bg-neutral-dark text-white px-2 py-0.5 rounded-md shadow-lg whitespace-nowrap z-10">
+                  Copied!
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+          <div className="mb-4">
+            <span className="text-sm font-semibold text-neutral-dark mb-1">他の絵文字:</span>
+            <div className="flex overflow-x-auto gap-2 py-2 scrollbar-thin scrollbar-thumb-neutral-medium/50 scrollbar-track-neutral-light">
               {instrumentEmojiArray.map((emoji, index) => (
                 <div key={index} className="relative">
                   <button
                     onClick={() => {
-                      setInstrumentEmoji(emoji);
+                      setSuffixEmoji(emoji);
                       handleEmojiCopy(emoji);
                     }}
                     className="p-1.5 text-xl bg-white rounded-md shadow-sm hover:bg-neutral-medium/20 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-accent"
@@ -136,6 +163,19 @@ function App() {
                   onChange={(e) => setInstrumentEmoji(e.target.value)}
                   className="w-full p-2 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
                   placeholder="🎸"
+                />
+              </div>
+              <div>
+                <label htmlFor="suffixEmojiInput" className="block text-sm font-semibold text-neutral-dark mb-1">
+                  後ろの絵文字
+                </label>
+                <input
+                  id="suffixEmojiInput"
+                  type="text"
+                  value={suffixEmoji}
+                  onChange={(e) => setSuffixEmoji(e.target.value)}
+                  className="w-full p-2 border border-neutral-medium rounded-md focus:ring-2 focus:ring-brand-accent focus:border-brand-accent"
+                  placeholder="🏘️"
                 />
               </div>
               <div>

--- a/src/hooks/useTweetState.test.ts
+++ b/src/hooks/useTweetState.test.ts
@@ -17,6 +17,12 @@ describe('parseStructuredFields', () => {
     expect(result?.instrument).toBe('🥁');
   });
 
+  it('extracts suffix emoji', () => {
+    const text = template.join('\n').replace('🏘️', '🎪');
+    const result = parseStructuredFields(text);
+    expect(result?.suffix).toBe('🎪');
+  });
+
   it('handles multi-line free text', () => {
     const multi = template.join('\n').replace('自由文', 'line1\nline2');
     const result = parseStructuredFields(multi);
@@ -26,14 +32,15 @@ describe('parseStructuredFields', () => {
 
 describe('buildStructuredTweet', () => {
   it('replaces placeholders and emoji', () => {
-    const result = buildStructuredTweet(template, 'test', 'World', 'Creator', '🎹');
+    const result = buildStructuredTweet(template, 'test', 'World', 'Creator', '🎹', '🎪');
     expect(result).toContain('第210回 🎹題名のないお茶会');
+    expect(result).toContain('題名のないお茶会🎪');
     expect(result).toContain('【場所】World By Creator');
     expect(result.startsWith('test #あ茶会')).toBe(true);
   });
 
   it('supports multi-line free text', () => {
-    const result = buildStructuredTweet(template, 'line1\nline2', 'World', 'Creator', '🎻');
+    const result = buildStructuredTweet(template, 'line1\nline2', 'World', 'Creator', '🎻', '🏠');
     expect(result.startsWith('line1\nline2 #あ茶会')).toBe(true);
   });
 });

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -16,6 +16,7 @@ export interface ParsedFields {
   world: string;
   creator: string;
   instrument: string;
+  suffix: string;
 }
 
 export function parseStructuredFields(text: string): ParsedFields | null {
@@ -26,13 +27,17 @@ export function parseStructuredFields(text: string): ParsedFields | null {
   if (!locationMatch) {
     return null;
   }
-  const meetingEmojiMatch = text.match(/第\d+回\s*(.*?)題名のないお茶会/);
+  const meetingEmojiMatch = text.match(
+    /第\d+回\s*(.*?)題名のないお茶会([^\n]*)/,
+  );
   const instrument = meetingEmojiMatch ? meetingEmojiMatch[1].trim() : '🎸';
+  const suffix = meetingEmojiMatch ? meetingEmojiMatch[2].trim() : '🏘️';
   return {
     freeText: free === '自由文' ? '' : free,
     world: locationMatch[1].trim() === 'ワールド名' ? '' : locationMatch[1].trim(),
     creator: locationMatch[2].trim() === 'クリエイター名' ? '' : locationMatch[2].trim(),
     instrument,
+    suffix,
   };
 }
 
@@ -42,6 +47,7 @@ export function buildStructuredTweet(
   world: string,
   creator: string,
   emoji: string,
+  suffix: string,
 ): string {
   if (!template.length) return '';
   const lines = [...template];
@@ -52,7 +58,10 @@ export function buildStructuredTweet(
         return `【場所】${world} By ${creator}`;
       }
       if (line.includes('題名のないお茶会')) {
-        return line.replace(/(第\d+回 )(.+?)(題名のないお茶会)/, `$1${emoji}$3`);
+        return line.replace(
+          /(第\d+回 )(.+?)(題名のないお茶会)([^\n]*)/,
+          `$1${emoji}$3${suffix}`,
+        );
       }
       return line;
     })
@@ -151,6 +160,7 @@ export function useTweetState() {
   const [worldName, setWorldName] = useState('');
   const [creatorName, setCreatorName] = useState('');
   const [instrumentEmoji, setInstrumentEmoji] = useState('🎸');
+  const [suffixEmoji, setSuffixEmoji] = useState('🏘️');
   const [structuredTemplate, setStructuredTemplate] = useState<string[]>([]);
 
   useEffect(() => {
@@ -169,10 +179,11 @@ export function useTweetState() {
           worldName,
           creatorName,
           instrumentEmoji,
+          suffixEmoji,
         ),
       );
     }
-  }, [freeText, worldName, creatorName, instrumentEmoji, structuredMode, structuredTemplate]);
+  }, [freeText, worldName, creatorName, instrumentEmoji, suffixEmoji, structuredMode, structuredTemplate]);
 
   const referenceDate = new Date('2025-02-02');
   const referenceMeetingNumber = 208;
@@ -209,7 +220,7 @@ export function useTweetState() {
       }
       const template =
         `自由文 #あ茶会\n\n` +
-        `第${meetingNumber}回 ${instrumentEmoji}題名のないお茶会🏘️\n` +
+        `第${meetingNumber}回 ${instrumentEmoji}題名のないお茶会${suffixEmoji}\n` +
         `【日時】${month}月${day}日(日) 14:30〜16:00\n` +
         `【場所】ワールド名 By クリエイター名\n` +
         `【参加方法】Group＋「題名のないお茶会」にjoin`;
@@ -255,6 +266,7 @@ export function useTweetState() {
     setWorldName(parsed.world);
     setCreatorName(parsed.creator);
     setInstrumentEmoji(parsed.instrument);
+    setSuffixEmoji(parsed.suffix);
     setStructuredTemplate(tweetText.split('\n'));
     setStructuredMode(true);
   };
@@ -280,6 +292,8 @@ export function useTweetState() {
     setCreatorName,
     instrumentEmoji,
     setInstrumentEmoji,
+    suffixEmoji,
+    setSuffixEmoji,
     structuredTemplate,
     generateThisWeeksSchedule,
     handleEmojiCopy,


### PR DESCRIPTION
## Summary
- allow editing the emoji placed after `題名のないお茶会`
- support choosing this suffix emoji from the instrument emoji list
- update state logic and structured template functions
- update tests for new field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be6c2491c8328a3389168fbba9492