### PR TITLE
Add persistence via localStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ function App() {
     handleEmojiCopy,
     handleTweetCopy,
     switchToStructuredMode,
+    clearStoredData,
     validation,
     tweetLength,
     maxTweetLength,
@@ -78,11 +79,17 @@ function App() {
                   Copied!
                 </span>
               )}
-              {validation.hasPlaceholders && (
-                <span className="mt-1 text-xs text-red-500">プレイスホルダーを埋めてください</span>
-              )}
-            </div>
+            {validation.hasPlaceholders && (
+              <span className="mt-1 text-xs text-red-500">プレイスホルダーを埋めてください</span>
+            )}
           </div>
+          <button
+            onClick={clearStoredData}
+            className="px-4 py-3 bg-brand-accent text-white rounded-lg hover:bg-opacity-85 transition-all duration-150 text-base font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-accent"
+          >
+            入力をクリア
+          </button>
+        </div>
 
           {/* New Emoji Helper Section */}
           <div className="mb-4">

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -150,18 +150,39 @@ export function validateTweet(
 }
 
 export function useTweetState() {
-  const [tweetText, setTweetText] = useState('');
+  let initialData: Partial<{
+    tweetText: string;
+    structuredMode: boolean;
+    freeText: string;
+    worldName: string;
+    creatorName: string;
+    instrumentEmoji: string;
+    suffixEmoji: string;
+    structuredTemplate: string[];
+  }> = {};
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('tweet-state');
+    if (stored) {
+      try {
+        initialData = JSON.parse(stored);
+      } catch {
+        initialData = {};
+      }
+    }
+  }
+
+  const [tweetText, setTweetText] = useState(initialData.tweetText || '');
   const [charCount, setCharCount] = useState(0);
   const [animateCount, setAnimateCount] = useState(false);
   const [isLoadingSchedule, setIsLoadingSchedule] = useState(false);
   const [showCopyFeedbackFor, setShowCopyFeedbackFor] = useState<string | null>(null);
-  const [structuredMode, setStructuredMode] = useState(false);
-  const [freeText, setFreeText] = useState('');
-  const [worldName, setWorldName] = useState('');
-  const [creatorName, setCreatorName] = useState('');
-  const [instrumentEmoji, setInstrumentEmoji] = useState('🎸');
-  const [suffixEmoji, setSuffixEmoji] = useState('🏘️');
-  const [structuredTemplate, setStructuredTemplate] = useState<string[]>([]);
+  const [structuredMode, setStructuredMode] = useState(initialData.structuredMode || false);
+  const [freeText, setFreeText] = useState(initialData.freeText || '');
+  const [worldName, setWorldName] = useState(initialData.worldName || '');
+  const [creatorName, setCreatorName] = useState(initialData.creatorName || '');
+  const [instrumentEmoji, setInstrumentEmoji] = useState(initialData.instrumentEmoji || '🎸');
+  const [suffixEmoji, setSuffixEmoji] = useState(initialData.suffixEmoji || '🏘️');
+  const [structuredTemplate, setStructuredTemplate] = useState<string[]>(initialData.structuredTemplate || []);
 
   useEffect(() => {
     setCharCount(countTweetLength(tweetText));
@@ -184,6 +205,22 @@ export function useTweetState() {
       );
     }
   }, [freeText, worldName, creatorName, instrumentEmoji, suffixEmoji, structuredMode, structuredTemplate]);
+
+  useEffect(() => {
+    const data = {
+      tweetText,
+      structuredMode,
+      freeText,
+      worldName,
+      creatorName,
+      instrumentEmoji,
+      suffixEmoji,
+      structuredTemplate,
+    };
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('tweet-state', JSON.stringify(data));
+    }
+  }, [tweetText, structuredMode, freeText, worldName, creatorName, instrumentEmoji, suffixEmoji, structuredTemplate]);
 
   const referenceDate = new Date('2025-02-02');
   const referenceMeetingNumber = 208;
@@ -256,6 +293,20 @@ export function useTweetState() {
       .catch((err) => console.error('Failed to copy text: ', err));
   };
 
+  const clearStoredData = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('tweet-state');
+    }
+    setTweetText('');
+    setFreeText('');
+    setWorldName('');
+    setCreatorName('');
+    setInstrumentEmoji('🎸');
+    setSuffixEmoji('🏘️');
+    setStructuredTemplate([]);
+    setStructuredMode(false);
+  };
+
   const switchToStructuredMode = () => {
     const parsed = parseStructuredFields(tweetText);
     if (!parsed) {
@@ -299,6 +350,7 @@ export function useTweetState() {
     handleEmojiCopy,
     handleTweetCopy,
     switchToStructuredMode,
+    clearStoredData,
     validation,
     tweetLength,
     maxTweetLength,


### PR DESCRIPTION
## Summary
- keep tweet state in localStorage
- add ability to clear saved data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f232140488328818d0f890abc009f