### PR TITLE
Fix multiline location parsing in tweet validation

### DIFF
--- a/src/hooks/useTweetState.test.ts
+++ b/src/hooks/useTweetState.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseStructuredFields,
   buildStructuredTweet,
+  extractLocation,
   validateTweet,
 } from './useTweetState';
 
@@ -47,6 +48,51 @@ describe('buildStructuredTweet', () => {
     const result = buildStructuredTweet(template, 'line1\nline2', 'World', 'Creator', '🎻', '🏠');
     expect(result.startsWith('line1\nline2 #あ茶会')).toBe(true);
   });
+
+  it('does not duplicate lines when world name contains newlines', () => {
+    // Simulate a template generated with a multiline world name from a spreadsheet
+    const multilineWorld = 'DOBUITA ＆ MIKASA WORLD\n（メタバースヨコスカ）';
+    const creator = 'MetasukaVR';
+    const templateWithMultiline = [
+      '自由文 #あ茶会',
+      '',
+      '第259回 🎷題名のないお茶会🍫',
+      '【日時】3月1日(日) 14:30〜16:00',
+      `【場所】DOBUITA ＆ MIKASA WORLD`,
+      `（メタバースヨコスカ） By MetasukaVR`,
+      '【参加方法】Group＋「題名のないお茶会」にjoin',
+    ];
+    const result = buildStructuredTweet(
+      templateWithMultiline, 'test', multilineWorld, creator, '🎷', '🍫',
+    );
+    const occurrences = result.split('（メタバースヨコスカ）').length - 1;
+    expect(occurrences).toBe(1);
+    expect(result).toContain(`【場所】DOBUITA ＆ MIKASA WORLD\n（メタバースヨコスカ） By MetasukaVR`);
+    expect(result).toContain('【参加方法】');
+  });
+});
+
+describe('extractLocation', () => {
+  it('extracts single-line location', () => {
+    const text = '【場所】MyWorld By Creator\n【参加方法】join';
+    const result = extractLocation(text);
+    expect(result).toEqual({ world: 'MyWorld', creator: 'Creator' });
+  });
+
+  it('extracts multiline location', () => {
+    const text = '【場所】DOBUITA ＆ MIKASA WORLD\n（メタバースヨコスカ） By MetasukaVR\n【参加方法】join';
+    const result = extractLocation(text);
+    expect(result?.world).toBe('DOBUITA ＆ MIKASA WORLD\n（メタバースヨコスカ）');
+    expect(result?.creator).toBe('MetasukaVR');
+  });
+
+  it('returns null when no location section', () => {
+    expect(extractLocation('no location here')).toBeNull();
+  });
+
+  it('returns null when no By separator', () => {
+    expect(extractLocation('【場所】WorldOnly\n【参加方法】join')).toBeNull();
+  });
 });
 
 describe('validateTweet', () => {
@@ -63,6 +109,17 @@ describe('validateTweet', () => {
     const currentDate = new Date('2026-01-10');
     const result = validateTweet(text, undefined, undefined, currentDate);
     expect(result.hasNightWord).toBe(false);
+  });
+
+  it('validates tweet with multiline location', () => {
+    const tweet =
+      'テスト #あ茶会\n\n第259回 🎸題名のないお茶会🏘️\n【日時】3月1日(日) 14:30〜16:00\n【場所】DOBUITA ＆ MIKASA WORLD\n（メタバースヨコスカ） By MetasukaVR\n【参加方法】Group＋「題名のないお茶会」にjoin';
+    const currentDate = new Date('2026-02-23');
+    const result = validateTweet(tweet, new Date('2025-12-21'), 253, currentDate);
+    expect(result.hasValidLocation).toBe(true);
+    expect(result.extractedInfo.worldName).toBe('DOBUITA ＆ MIKASA WORLD\n（メタバースヨコスカ）');
+    expect(result.extractedInfo.creator).toBe('MetasukaVR');
+    expect(result.isValid).toBe(true);
   });
 
   describe('year calculation', () => {

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -25,12 +25,23 @@ export interface ParsedFields {
   suffix: string;
 }
 
+export function extractLocation(text: string): { world: string; creator: string } | null {
+  const blockMatch = text.match(/【場所】([\s\S]*?)(?=\n【|\s*$)/);
+  if (!blockMatch) return null;
+  const block = blockMatch[1];
+  const byIdx = block.lastIndexOf(' By ');
+  if (byIdx === -1) return null;
+  return {
+    world: block.substring(0, byIdx).trim(),
+    creator: block.substring(byIdx + 4).trim(),
+  };
+}
+
 export function parseStructuredFields(text: string): ParsedFields | null {
   const freeMatch = text.match(/^[\s\S]*?(?=#あ茶会)/);
   const free = freeMatch ? freeMatch[0].trim() : '';
-  const locationRegex = /【場所】([^\n]+)\s*By\s*(.+?)(?:\s*$|\n)/i;
-  const locationMatch = text.match(locationRegex);
-  if (!locationMatch) {
+  const location = extractLocation(text);
+  if (!location) {
     return null;
   }
   const meetingEmojiMatch = text.match(
@@ -40,8 +51,8 @@ export function parseStructuredFields(text: string): ParsedFields | null {
   const suffix = meetingEmojiMatch ? meetingEmojiMatch[2].trim() : '🏘️';
   return {
     freeText: free === '自由文' ? '' : free,
-    world: locationMatch[1].trim() === 'ワールド名' ? '' : locationMatch[1].trim(),
-    creator: locationMatch[2].trim() === 'クリエイター名' ? '' : locationMatch[2].trim(),
+    world: location.world === 'ワールド名' ? '' : location.world,
+    creator: location.creator === 'クリエイター名' ? '' : location.creator,
     instrument,
     suffix,
   };
@@ -58,11 +69,22 @@ export function buildStructuredTweet(
   if (!template.length) return '';
   const lines = [...template];
   lines[0] = `${free} #あ茶会`;
+
+  // Replace the entire location block (【場所】 line and any continuation lines
+  // before the next 【 section). This prevents duplicates when world names
+  // contain newlines (e.g. multiline values from the spreadsheet).
+  const locationIdx = lines.findIndex(line => line.startsWith('【場所】'));
+  if (locationIdx !== -1) {
+    let endIdx = locationIdx + 1;
+    while (endIdx < lines.length && !lines[endIdx].startsWith('【')) {
+      endIdx++;
+    }
+    const locationLines = `【場所】${world} By ${creator}`.split('\n');
+    lines.splice(locationIdx, endIdx - locationIdx, ...locationLines);
+  }
+
   return lines
     .map((line) => {
-      if (line.startsWith('【場所】')) {
-        return `【場所】${world} By ${creator}`;
-      }
       if (line.includes('題名のないお茶会')) {
         return line.replace(
           /(第\d+回 )(.+?)(題名のないお茶会)([^\n]*)/,
@@ -98,9 +120,8 @@ export function validateTweet(
   const timeRegex = /(\d{1,2}):(\d{2})〜(\d{1,2}):(\d{2})/;
   const timeMatch = text.match(timeRegex);
   const hasHashtag = text.includes('#あ茶会');
-  const locationRegex = /【場所】([^\n]+)\s*By\s*(.+?)(?:\s*$|\n)/i;
-  const locationMatch = text.match(locationRegex);
-  const hasValidLocation = locationMatch !== null;
+  const location = extractLocation(text);
+  const hasValidLocation = location !== null;
   const placeholdersRegex = /(ワールド名|クリエイター名|自由文)/;
   const hasPlaceholders = placeholdersRegex.test(text);
   const nightWordRegex = /(夜|宵|今宵|今夜)/;
@@ -175,8 +196,8 @@ export function validateTweet(
     extractedInfo: {
       date: dateMatch ? `${month}月${day}日(日)` : null,
       time,
-      worldName: locationMatch ? locationMatch[1].trim() : null,
-      creator: locationMatch ? locationMatch[2].trim() : null,
+      worldName: location ? location.world : null,
+      creator: location ? location.creator : null,
       meetingNumber: meetingNumber ? `第${meetingNumber}回` : null,
     },
   };


### PR DESCRIPTION
## Summary
Refactored location extraction logic to properly handle multiline world names (e.g., from spreadsheet data) and prevent duplication when building structured tweets.

## Key Changes
- **New `extractLocation()` function**: Extracted location parsing into a dedicated, reusable function that uses `lastIndexOf(' By ')` to correctly split world name and creator, supporting multiline world names
- **Updated `parseStructuredFields()`**: Now uses the new `extractLocation()` function instead of inline regex
- **Fixed `buildStructuredTweet()`**: Changed location replacement logic to handle the entire location block (including continuation lines before the next 【 section) rather than just the first line, preventing duplication when world names contain newlines
- **Updated `validateTweet()`**: Refactored to use `extractLocation()` for consistent location parsing

## Implementation Details
- The `extractLocation()` regex `/【場所】([\s\S]*?)(?=\n【|\s*$)/` captures the entire location block including newlines, then splits on the last occurrence of ` By ` to separate world name and creator
- Location block replacement in `buildStructuredTweet()` now identifies the location section start and finds where it ends (at the next 【 marker or end of array), then replaces all those lines at once
- Added comprehensive test coverage for multiline location scenarios

https://claude.ai/code/session_01M4jVDp8f3iLFgz7WbaS5fW