### PR TITLE
Add schedule announcement tweet generation feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
   Trash2,
   Edit3,
   Eye,
+  Megaphone,
 } from 'lucide-react';
 import useTweetState, { instrumentEmojiArray } from './hooks/useTweetState';
 
@@ -39,6 +40,7 @@ function App() {
     suffixEmoji,
     setSuffixEmoji,
     generateThisWeeksSchedule,
+    generateScheduleAnnouncementTweet,
     handleEmojiCopy,
     handleTweetCopy,
     switchToStructuredMode,
@@ -230,23 +232,33 @@ function App() {
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
             <h2 className="text-lg font-bold text-neutral-dark">ツイート作成</h2>
             {!isScheduleExpired && (
-              <button
-                onClick={generateThisWeeksSchedule}
-                disabled={isLoadingSchedule}
-                className="px-4 py-2 bg-brand-primary text-white rounded-lg hover:bg-opacity-90 transition-all duration-150 text-sm font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center"
-              >
-                {isLoadingSchedule ? (
-                  <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    生成中...
-                  </>
-                ) : (
-                  <>
-                    <Calendar className="w-4 h-4 mr-2" />
-                    今週の予定を生成
-                  </>
-                )}
-              </button>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={generateThisWeeksSchedule}
+                  disabled={isLoadingSchedule}
+                  className="px-4 py-2 bg-brand-primary text-white rounded-lg hover:bg-opacity-90 transition-all duration-150 text-sm font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center"
+                >
+                  {isLoadingSchedule ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      生成中...
+                    </>
+                  ) : (
+                    <>
+                      <Calendar className="w-4 h-4 mr-2" />
+                      今週の予定を生成
+                    </>
+                  )}
+                </button>
+                <button
+                  onClick={generateScheduleAnnouncementTweet}
+                  disabled={isSheetLoading}
+                  className="px-4 py-2 bg-brand-secondary text-white rounded-lg hover:bg-opacity-90 transition-all duration-150 text-sm font-medium shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-secondary focus:ring-offset-2 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center"
+                >
+                  <Megaphone className="w-4 h-4 mr-2" />
+                  予定お知らせを生成
+                </button>
+              </div>
             )}
           </div>
 

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -3,6 +3,7 @@ import {
   fetchScheduleFromSheet,
   findEntryByDate,
   deriveSkippedDates,
+  generateScheduleAnnouncement,
   type ScheduleEntry,
 } from '../lib/fetchSheetSchedule';
 
@@ -342,6 +343,31 @@ export function useTweetState() {
     }, 300);
   };
 
+  const generateScheduleAnnouncementTweet = () => {
+    if (
+      tweetText.trim() !== '' ||
+      freeText.trim() !== '' ||
+      worldName.trim() !== '' ||
+      creatorName.trim() !== ''
+    ) {
+      const confirmed = window.confirm('現在の入力内容は上書きされます。続行しますか?');
+      if (!confirmed) {
+        return;
+      }
+    }
+    const announcement = generateScheduleAnnouncement(sheetSchedule);
+    if (!announcement) {
+      alert('予定データがありません。スプレッドシートを読み込んでください。');
+      return;
+    }
+    setTweetText(announcement);
+    setStructuredMode(false);
+    setStructuredTemplate([]);
+    setFreeText('');
+    setWorldName('');
+    setCreatorName('');
+  };
+
   const handleEmojiCopy = (emoji: string) => {
     navigator.clipboard
       .writeText(emoji)
@@ -431,6 +457,7 @@ export function useTweetState() {
     setSuffixEmoji,
     structuredTemplate,
     generateThisWeeksSchedule,
+    generateScheduleAnnouncementTweet,
     handleEmojiCopy,
     handleTweetCopy,
     switchToStructuredMode,

--- a/src/lib/fetchSheetSchedule.test.ts
+++ b/src/lib/fetchSheetSchedule.test.ts
@@ -5,6 +5,7 @@ import {
   formatDateForSheet,
   findEntryByDate,
   deriveSkippedDates,
+  generateScheduleAnnouncement,
 } from './fetchSheetSchedule';
 
 describe('parseCSV', () => {
@@ -145,5 +146,67 @@ describe('deriveSkippedDates', () => {
       { date: '2026/02/01', meetingNumber: 256, worldName: 'W', creator: 'C' },
     ];
     expect(deriveSkippedDates(noSkips)).toEqual([]);
+  });
+});
+
+describe('generateScheduleAnnouncement', () => {
+  const entries = [
+    { date: '2025/12/21', meetingNumber: 253, worldName: 'W1', creator: 'C1' },
+    { date: '2025/12/28', meetingNumber: null, worldName: '', creator: '' },
+    { date: '2026/01/04', meetingNumber: null, worldName: '', creator: '' },
+    { date: '2026/01/11', meetingNumber: 254, worldName: 'W2', creator: 'C2' },
+    { date: '2026/01/18', meetingNumber: 255, worldName: 'W3', creator: 'C3' },
+    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '' },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'W4', creator: 'C4' },
+  ];
+
+  it('generates announcement starting from the next Sunday', () => {
+    // Wednesday Dec 17, 2025 → next Sunday is Dec 21
+    const result = generateScheduleAnnouncement(entries, new Date(2025, 11, 17));
+    expect(result).toContain('#あ茶会 12月の予定をお知らせします');
+    expect(result).toContain('12/21 🍵');
+    expect(result).toContain('12/28 - お休み -');
+  });
+
+  it('marks skipped dates with お休み', () => {
+    const result = generateScheduleAnnouncement(entries, new Date(2025, 11, 17));
+    expect(result).toContain('12/28 - お休み -');
+    expect(result).toContain('1/4 - お休み -');
+  });
+
+  it('adds year-first annotation for the first active event of a new year', () => {
+    // Start from Dec 21 → 12/21 is active in 2025, so 1/11 is first active in 2026
+    const result = generateScheduleAnnouncement(entries, new Date(2025, 11, 17));
+    expect(result).toContain('1/11 🍵（2026年初）');
+  });
+
+  it('does not add year-first annotation when the year already had an active event before range', () => {
+    // Start from Jan 11 → 2026 already had no active event before,
+    // but 2025 had one (12/21), so 1/11 is first active of 2026
+    const result = generateScheduleAnnouncement(entries, new Date(2026, 0, 7));
+    expect(result).toContain('1/11 🍵（2026年初）');
+  });
+
+  it('does not add year-first annotation if prior active event exists in that year', () => {
+    // Start from Jan 18 → 2026 already had active 1/11 before range
+    const result = generateScheduleAnnouncement(entries, new Date(2026, 0, 14));
+    expect(result).toContain('1/18 🍵');
+    expect(result).not.toContain('1/18 🍵（2026年初）');
+  });
+
+  it('respects weeksCount parameter', () => {
+    const result = generateScheduleAnnouncement(entries, new Date(2025, 11, 17), 3);
+    const lines = result.split('\n').filter(l => l.match(/^\d+\//));
+    expect(lines).toHaveLength(3);
+  });
+
+  it('returns empty string when no upcoming entries', () => {
+    const result = generateScheduleAnnouncement(entries, new Date(2027, 0, 1));
+    expect(result).toBe('');
+  });
+
+  it('uses header month from the first entry', () => {
+    const result = generateScheduleAnnouncement(entries, new Date(2026, 0, 7));
+    expect(result).toContain('#あ茶会 1月の予定をお知らせします');
   });
 });

--- a/src/lib/fetchSheetSchedule.ts
+++ b/src/lib/fetchSheetSchedule.ts
@@ -129,3 +129,66 @@ export function deriveSkippedDates(entries: ScheduleEntry[]): Date[] {
       return new Date(y, m - 1, d);
     });
 }
+
+/** Generate a schedule announcement tweet from sheet data.
+ *  Format:
+ *  #あ茶会 N月の予定をお知らせします
+ *
+ *  M/D 🍵
+ *  M/D - お休み -
+ */
+export function generateScheduleAnnouncement(
+  entries: ScheduleEntry[],
+  currentDate: Date = new Date(),
+  weeksCount = 6,
+): string {
+  // Find the nearest upcoming Sunday (including today)
+  const startSunday = new Date(currentDate);
+  startSunday.setHours(0, 0, 0, 0);
+  while (startSunday.getDay() !== 0) startSunday.setDate(startSunday.getDate() + 1);
+
+  // Filter entries from startSunday onward
+  const upcoming = entries.filter(e => {
+    const [y, m, d] = e.date.split('/').map(Number);
+    const entryDate = new Date(y, m - 1, d);
+    entryDate.setHours(0, 0, 0, 0);
+    return entryDate >= startSunday;
+  }).slice(0, weeksCount);
+
+  if (upcoming.length === 0) return '';
+
+  const firstMonth = Number.parseInt(upcoming[0].date.split('/')[1]);
+
+  let text = `#あ茶会 ${firstMonth}月の予定をお知らせします\n\n`;
+
+  // Track years that already had an active event (before or within the range)
+  const yearsWithPriorActive = new Set<number>();
+  for (const e of entries) {
+    const [y, m, d] = e.date.split('/').map(Number);
+    const entryDate = new Date(y, m - 1, d);
+    if (entryDate >= startSunday) break;
+    if (e.meetingNumber !== null) {
+      yearsWithPriorActive.add(y);
+    }
+  }
+  const yearsSeenActive = new Set(yearsWithPriorActive);
+
+  for (const entry of upcoming) {
+    const [y, m, d] = entry.date.split('/').map(Number);
+    const isSkipped = entry.meetingNumber === null;
+
+    let annotation = '';
+    if (!isSkipped && !yearsSeenActive.has(y)) {
+      annotation = `（${y}年初）`;
+      yearsSeenActive.add(y);
+    }
+
+    if (isSkipped) {
+      text += `${m}/${d} - お休み -\n`;
+    } else {
+      text += `${m}/${d} 🍵${annotation}\n`;
+    }
+  }
+
+  return text.trimEnd();
+}


### PR DESCRIPTION
## Summary
This PR adds a new feature to generate schedule announcement tweets that display upcoming meetings for the next 6 weeks, with support for marking skipped dates and highlighting the first active event of each year.

## Key Changes
- **New function `generateScheduleAnnouncement()`** in `fetchSheetSchedule.ts`:
  - Generates formatted announcement text starting from the next Sunday
  - Marks skipped dates with "- お休み -"
  - Adds year-first annotation "（YYYY年初）" for the first active event of each year
  - Supports configurable week count (default 6 weeks)
  - Returns empty string when no upcoming entries exist

- **Comprehensive test suite** in `fetchSheetSchedule.test.ts`:
  - Tests for correct Sunday calculation and date filtering
  - Tests for skipped date marking
  - Tests for year-first annotation logic (with and without prior events)
  - Tests for configurable week count and edge cases

- **UI integration** in `App.tsx`:
  - Added new "予定お知らせを生成" (Generate Schedule Announcement) button
  - Button uses secondary brand color and megaphone icon
  - Positioned alongside existing "今週の予定を生成" button in a flex container

- **Hook integration** in `useTweetState.ts`:
  - New `generateScheduleAnnouncementTweet()` function that:
    - Validates no unsaved changes before overwriting
    - Generates announcement and populates tweet text
    - Switches to free text mode (disables structured mode)
    - Clears all other input fields

## Implementation Details
- The announcement format follows: `#あ茶会 N月の予定をお知らせします` header followed by date entries
- Year-first annotation logic tracks which years have already seen active events before the announcement range
- Date parsing uses the existing `ScheduleEntry` format (YYYY/MM/DD strings)
- All dates are normalized to midnight UTC for consistent comparison

https://claude.ai/code/session_01BcDbZ5e9v5ZKp65GjU9xsw