### PR TITLE
Add confirmed status tracking to schedule entries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,6 +126,7 @@ function App() {
                   <table className="w-full text-xs">
                     <thead>
                       <tr className="border-b border-neutral-medium/20">
+                        <th className="text-center py-2 px-2 text-neutral-medium font-medium">確定</th>
                         <th className="text-left py-2 px-2 text-neutral-medium font-medium">日付</th>
                         <th className="text-left py-2 px-2 text-neutral-medium font-medium">回</th>
                         <th className="text-left py-2 px-2 text-neutral-medium font-medium">ワールド名</th>
@@ -157,6 +158,13 @@ function App() {
                                     : ''
                               }`}
                             >
+                              <td className="py-1.5 px-2 text-center">
+                                {entry.confirmed ? (
+                                  <CheckCircle className="w-4 h-4 text-green-500 inline" />
+                                ) : (
+                                  <span className="w-4 h-4 inline-block rounded-full border-2 border-neutral-medium/30" />
+                                )}
+                              </td>
                               <td className="py-1.5 px-2 whitespace-nowrap">
                                 {isThisWeek && <span className="mr-1">▶</span>}
                                 {entry.date}

--- a/src/lib/fetchSheetSchedule.test.ts
+++ b/src/lib/fetchSheetSchedule.test.ts
@@ -78,6 +78,13 @@ describe('parseScheduleCSV', () => {
     expect(entries[2].meetingNumber).toBeNull(); // "-" means skipped
   });
 
+  it('extracts confirmed status from checkbox row', () => {
+    const entries = parseScheduleCSV(sampleCSV);
+    expect(entries[0].confirmed).toBe(true);
+    expect(entries[1].confirmed).toBe(false);
+    expect(entries[2].confirmed).toBe(false);
+  });
+
   it('extracts world names and creators', () => {
     const entries = parseScheduleCSV(sampleCSV);
     expect(entries[0].worldName).toBe('Stardust Piano');
@@ -109,9 +116,9 @@ describe('formatDateForSheet', () => {
 
 describe('findEntryByDate', () => {
   const entries = [
-    { date: '2026/02/01', meetingNumber: 256, worldName: 'World1', creator: 'Creator1' },
-    { date: '2026/02/08', meetingNumber: 257, worldName: 'World2', creator: 'Creator2' },
-    { date: '2026/02/15', meetingNumber: null, worldName: '', creator: '' },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'World1', creator: 'Creator1', confirmed: true },
+    { date: '2026/02/08', meetingNumber: 257, worldName: 'World2', creator: 'Creator2', confirmed: false },
+    { date: '2026/02/15', meetingNumber: null, worldName: '', creator: '', confirmed: false },
   ];
 
   it('finds entry matching date', () => {
@@ -127,9 +134,9 @@ describe('findEntryByDate', () => {
 
 describe('deriveSkippedDates', () => {
   const entries = [
-    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '' },
-    { date: '2026/02/01', meetingNumber: 256, worldName: 'World', creator: 'Creator' },
-    { date: '2026/02/22', meetingNumber: null, worldName: '', creator: '' },
+    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '', confirmed: false },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'World', creator: 'Creator', confirmed: true },
+    { date: '2026/02/22', meetingNumber: null, worldName: '', creator: '', confirmed: false },
   ];
 
   it('extracts dates with null meeting numbers', () => {
@@ -143,7 +150,7 @@ describe('deriveSkippedDates', () => {
 
   it('returns empty array when no skipped dates', () => {
     const noSkips = [
-      { date: '2026/02/01', meetingNumber: 256, worldName: 'W', creator: 'C' },
+      { date: '2026/02/01', meetingNumber: 256, worldName: 'W', creator: 'C', confirmed: true },
     ];
     expect(deriveSkippedDates(noSkips)).toEqual([]);
   });
@@ -151,13 +158,13 @@ describe('deriveSkippedDates', () => {
 
 describe('generateScheduleAnnouncement', () => {
   const entries = [
-    { date: '2025/12/21', meetingNumber: 253, worldName: 'W1', creator: 'C1' },
-    { date: '2025/12/28', meetingNumber: null, worldName: '', creator: '' },
-    { date: '2026/01/04', meetingNumber: null, worldName: '', creator: '' },
-    { date: '2026/01/11', meetingNumber: 254, worldName: 'W2', creator: 'C2' },
-    { date: '2026/01/18', meetingNumber: 255, worldName: 'W3', creator: 'C3' },
-    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '' },
-    { date: '2026/02/01', meetingNumber: 256, worldName: 'W4', creator: 'C4' },
+    { date: '2025/12/21', meetingNumber: 253, worldName: 'W1', creator: 'C1', confirmed: true },
+    { date: '2025/12/28', meetingNumber: null, worldName: '', creator: '', confirmed: false },
+    { date: '2026/01/04', meetingNumber: null, worldName: '', creator: '', confirmed: false },
+    { date: '2026/01/11', meetingNumber: 254, worldName: 'W2', creator: 'C2', confirmed: true },
+    { date: '2026/01/18', meetingNumber: 255, worldName: 'W3', creator: 'C3', confirmed: true },
+    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '', confirmed: false },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'W4', creator: 'C4', confirmed: true },
   ];
 
   it('generates announcement starting from the next Sunday', () => {

--- a/src/lib/fetchSheetSchedule.ts
+++ b/src/lib/fetchSheetSchedule.ts
@@ -6,6 +6,7 @@ export interface ScheduleEntry {
   meetingNumber: number | null;
   worldName: string;
   creator: string;
+  confirmed: boolean;
 }
 
 export async function fetchScheduleFromSheet(): Promise<ScheduleEntry[]> {
@@ -77,6 +78,7 @@ export function parseScheduleCSV(csv: string): ScheduleEntry[] {
   const meetingRow = findRow('開催回数');
   const worldRow = findRow('ワールド名');
   const creatorRow = findRow('作者');
+  const confirmedRow = findRow('チェックが入っていたら確定分');
 
   if (!dateRow || !meetingRow) return [];
 
@@ -97,6 +99,7 @@ export function parseScheduleCSV(csv: string): ScheduleEntry[] {
       meetingNumber: Number.isNaN(meetingNumber) ? null : meetingNumber,
       worldName: worldRow?.[i]?.trim() || '',
       creator: creatorRow?.[i]?.trim() || '',
+      confirmed: confirmedRow?.[i]?.trim().toUpperCase() === 'TRUE',
     });
   }
 


### PR DESCRIPTION
## Summary
This PR adds support for tracking confirmed/unconfirmed status of schedule entries by reading from a checkbox column in the Google Sheet and displaying the status in the UI.

## Key Changes
- **Data Model**: Added `confirmed: boolean` field to `ScheduleEntry` interface
- **CSV Parsing**: Updated `parseScheduleCSV()` to extract the confirmed status from the "チェックが入っていたら確定分" (checkbox) row, treating "TRUE" values as confirmed
- **UI Display**: 
  - Added a new "確定" (Confirmed) column header to the schedule table
  - Displays a green checkmark icon for confirmed entries and an empty circle for unconfirmed entries
  - Positioned as the first column in the table
- **Tests**: Updated all test fixtures to include the `confirmed` property with appropriate values

## Implementation Details
- The confirmed status is determined by checking if the checkbox row value equals "TRUE" (case-insensitive)
- The UI uses a `CheckCircle` icon for confirmed entries and a styled empty circle for unconfirmed ones
- All existing test cases have been updated to maintain compatibility with the new required field

https://claude.ai/code/session_0117nXvEW3wV1hG5AricVEaX