### PR TITLE
Add world description support and VRChat API integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import {
   Edit3,
   Eye,
   Megaphone,
+  ExternalLink,
+  FileText,
 } from 'lucide-react';
 import useTweetState, { instrumentEmojiArray } from './hooks/useTweetState';
 
@@ -53,6 +55,7 @@ function App() {
     sheetError,
     sheetSchedule,
     loadSheetSchedule,
+    thisWeekEntry,
   } = useTweetState();
 
   const [isEmojiSectionOpen, setIsEmojiSectionOpen] = useState(false);
@@ -193,6 +196,29 @@ function App() {
                 <p className="text-sm text-neutral-medium py-3 text-center">
                   データがありません
                 </p>
+              )}
+              {/* 今週のワールド詳細（URL・説明） */}
+              {!isSheetLoading && thisWeekEntry && thisWeekEntry.meetingNumber !== null && (thisWeekEntry.worldUrl || thisWeekEntry.worldDescription) && (
+                <div className="mt-3 p-3 bg-brand-primary/5 border border-brand-primary/20 rounded-lg">
+                  <p className="text-xs font-semibold text-brand-primary mb-2">今週のワールド詳細</p>
+                  {thisWeekEntry.worldUrl && (
+                    <a
+                      href={thisWeekEntry.worldUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800 hover:underline mb-1.5 break-all"
+                    >
+                      <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                      {thisWeekEntry.worldUrl}
+                    </a>
+                  )}
+                  {thisWeekEntry.worldDescription && (
+                    <div className="flex items-start gap-1.5 text-xs text-neutral-dark">
+                      <FileText className="w-3 h-3 flex-shrink-0 mt-0.5 text-neutral-medium" />
+                      <p className="whitespace-pre-wrap">{thisWeekEntry.worldDescription}</p>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,8 @@ function App() {
     sheetSchedule,
     loadSheetSchedule,
     thisWeekEntry,
+    vrchatWorldInfo,
+    isVrchatWorldLoading,
   } = useTweetState();
 
   const [isEmojiSectionOpen, setIsEmojiSectionOpen] = useState(false);
@@ -198,26 +200,37 @@ function App() {
                 </p>
               )}
               {/* 今週のワールド詳細（URL・説明） */}
-              {!isSheetLoading && thisWeekEntry && thisWeekEntry.meetingNumber !== null && (thisWeekEntry.worldUrl || thisWeekEntry.worldDescription) && (
+              {!isSheetLoading && thisWeekEntry && thisWeekEntry.meetingNumber !== null && thisWeekEntry.worldUrl && (
                 <div className="mt-3 p-3 bg-brand-primary/5 border border-brand-primary/20 rounded-lg">
                   <p className="text-xs font-semibold text-brand-primary mb-2">今週のワールド詳細</p>
-                  {thisWeekEntry.worldUrl && (
-                    <a
-                      href={thisWeekEntry.worldUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800 hover:underline mb-1.5 break-all"
-                    >
-                      <ExternalLink className="w-3 h-3 flex-shrink-0" />
-                      {thisWeekEntry.worldUrl}
-                    </a>
-                  )}
-                  {thisWeekEntry.worldDescription && (
+                  {/* URL リンク */}
+                  <a
+                    href={thisWeekEntry.worldUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800 hover:underline mb-2 break-all"
+                  >
+                    <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                    {thisWeekEntry.worldUrl}
+                  </a>
+                  {/* VRChat API から取得した説明（取得中・取得済み・フォールバック） */}
+                  {isVrchatWorldLoading ? (
+                    <div className="flex items-center gap-1.5 text-xs text-neutral-medium">
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                      VRChat からワールド情報を取得中...
+                    </div>
+                  ) : vrchatWorldInfo?.description ? (
+                    <div className="flex items-start gap-1.5 text-xs text-neutral-dark">
+                      <FileText className="w-3 h-3 flex-shrink-0 mt-0.5 text-neutral-medium" />
+                      <p className="whitespace-pre-wrap">{vrchatWorldInfo.description}</p>
+                    </div>
+                  ) : thisWeekEntry.worldDescription ? (
+                    // VRChat API が取得できなかった場合はスプレッドシートの説明を表示
                     <div className="flex items-start gap-1.5 text-xs text-neutral-dark">
                       <FileText className="w-3 h-3 flex-shrink-0 mt-0.5 text-neutral-medium" />
                       <p className="whitespace-pre-wrap">{thisWeekEntry.worldDescription}</p>
                     </div>
-                  )}
+                  ) : null}
                 </div>
               )}
             </div>

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -271,27 +271,6 @@ export function useTweetState() {
     loadSheetSchedule();
   }, [loadSheetSchedule]);
 
-  // 今週エントリのURLが変わるたびに VRChat API からワールド詳細を取得する。
-  // CORS またはセッション未ログイン時は null のまま（フォールバック表示に任せる）。
-  useEffect(() => {
-    const url = thisWeekEntry?.worldUrl;
-    if (!url) {
-      setVrchatWorldInfo(null);
-      return;
-    }
-    const worldId = extractVRChatWorldId(url);
-    if (!worldId) {
-      setVrchatWorldInfo(null);
-      return;
-    }
-    setIsVrchatWorldLoading(true);
-    setVrchatWorldInfo(null);
-    fetchVRChatWorldInfo(worldId).then(info => {
-      setVrchatWorldInfo(info);
-      setIsVrchatWorldLoading(false);
-    });
-  }, [thisWeekEntry?.worldUrl]);
-
   useEffect(() => {
     setCharCount(countTweetLength(tweetText));
     setAnimateCount(true);
@@ -341,6 +320,28 @@ export function useTweetState() {
     return d;
   })();
   const thisWeekEntry = findEntryByDate(sheetSchedule, upcomingSunday);
+
+  // 今週エントリのURLが変わるたびに VRChat API からワールド詳細を取得する。
+  // thisWeekEntry の宣言より後に配置することで TDZ エラーを防ぐ。
+  // CORS またはセッション未ログイン時は null のまま（フォールバック表示に任せる）。
+  useEffect(() => {
+    const url = thisWeekEntry?.worldUrl;
+    if (!url) {
+      setVrchatWorldInfo(null);
+      return;
+    }
+    const worldId = extractVRChatWorldId(url);
+    if (!worldId) {
+      setVrchatWorldInfo(null);
+      return;
+    }
+    setIsVrchatWorldLoading(true);
+    setVrchatWorldInfo(null);
+    fetchVRChatWorldInfo(worldId).then(info => {
+      setVrchatWorldInfo(info);
+      setIsVrchatWorldLoading(false);
+    });
+  }, [thisWeekEntry?.worldUrl]);
 
   const generateThisWeeksSchedule = () => {
     if (

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -6,6 +6,11 @@ import {
   generateScheduleAnnouncement,
   type ScheduleEntry,
 } from '../lib/fetchSheetSchedule';
+import {
+  extractVRChatWorldId,
+  fetchVRChatWorldInfo,
+  type VRChatWorldInfo,
+} from '../lib/fetchVRChatWorld';
 
 export const instrumentEmojiArray = '🎸 🎹 🥁 🎺 🎻 🎷 🪕 🪗 🎤 🎧 📯 🪘 🎼'.split(' ');
 
@@ -242,6 +247,8 @@ export function useTweetState() {
   const [sheetSkippedDates, setSheetSkippedDates] = useState<Date[]>(skippedDates);
   const [isSheetLoading, setIsSheetLoading] = useState(false);
   const [sheetError, setSheetError] = useState<string | null>(null);
+  const [vrchatWorldInfo, setVrchatWorldInfo] = useState<VRChatWorldInfo | null>(null);
+  const [isVrchatWorldLoading, setIsVrchatWorldLoading] = useState(false);
 
   const loadSheetSchedule = useCallback(async () => {
     setIsSheetLoading(true);
@@ -263,6 +270,27 @@ export function useTweetState() {
   useEffect(() => {
     loadSheetSchedule();
   }, [loadSheetSchedule]);
+
+  // 今週エントリのURLが変わるたびに VRChat API からワールド詳細を取得する。
+  // CORS またはセッション未ログイン時は null のまま（フォールバック表示に任せる）。
+  useEffect(() => {
+    const url = thisWeekEntry?.worldUrl;
+    if (!url) {
+      setVrchatWorldInfo(null);
+      return;
+    }
+    const worldId = extractVRChatWorldId(url);
+    if (!worldId) {
+      setVrchatWorldInfo(null);
+      return;
+    }
+    setIsVrchatWorldLoading(true);
+    setVrchatWorldInfo(null);
+    fetchVRChatWorldInfo(worldId).then(info => {
+      setVrchatWorldInfo(info);
+      setIsVrchatWorldLoading(false);
+    });
+  }, [thisWeekEntry?.worldUrl]);
 
   useEffect(() => {
     setCharCount(countTweetLength(tweetText));
@@ -501,6 +529,8 @@ export function useTweetState() {
     sheetSchedule,
     loadSheetSchedule,
     thisWeekEntry,
+    vrchatWorldInfo,
+    isVrchatWorldLoading,
   };
 }
 

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -305,6 +305,15 @@ export function useTweetState() {
   const referenceDate = new Date('2025-12-21');
   const referenceMeetingNumber = 253;
 
+  // 今週（直近の日曜日）のスケジュールエントリを取得
+  const upcomingSunday = (() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    while (d.getDay() !== 0) d.setDate(d.getDate() + 1);
+    return d;
+  })();
+  const thisWeekEntry = findEntryByDate(sheetSchedule, upcomingSunday);
+
   const generateThisWeeksSchedule = () => {
     if (
       tweetText.trim() !== '' ||
@@ -491,6 +500,7 @@ export function useTweetState() {
     sheetError,
     sheetSchedule,
     loadSheetSchedule,
+    thisWeekEntry,
   };
 }
 

--- a/src/lib/fetchSheetSchedule.test.ts
+++ b/src/lib/fetchSheetSchedule.test.ts
@@ -65,6 +65,7 @@ describe('parseScheduleCSV', () => {
     '"ワールド名","Stardust Piano","ケセドのバレンタインデイ",""',
     '"作者","nekobus_17","ケセドCHESED",""',
     '"url","https://example.com","https://example2.com",""',
+    '"説明","ピアノが美しいワールドです","バレンタインデイをテーマにしたワールド",""',
   ].join('\n');
 
   it('parses schedule entries from transposed CSV', () => {
@@ -84,6 +85,26 @@ describe('parseScheduleCSV', () => {
     expect(entries[0].worldUrl).toBe('https://example.com');
     expect(entries[1].worldUrl).toBe('https://example2.com');
     expect(entries[2].worldUrl).toBe('');
+  });
+
+  it('extracts world descriptions from 説明 row', () => {
+    const entries = parseScheduleCSV(sampleCSV);
+    expect(entries[0].worldDescription).toBe('ピアノが美しいワールドです');
+    expect(entries[1].worldDescription).toBe('バレンタインデイをテーマにしたワールド');
+    expect(entries[2].worldDescription).toBe('');
+  });
+
+  it('returns empty string for worldDescription when 説明 row is absent', () => {
+    const csvWithoutDescription = [
+      '"開催予定日","2026/02/01"',
+      '"開催回数","256"',
+      '"ワールド名","TestWorld"',
+      '"作者","TestCreator"',
+      '"チェックが入っていたら確定分","TRUE"',
+      '"url","https://example.com"',
+    ].join('\n');
+    const entries = parseScheduleCSV(csvWithoutDescription);
+    expect(entries[0].worldDescription).toBe('');
   });
 
   it('extracts confirmed status from checkbox row', () => {
@@ -124,9 +145,9 @@ describe('formatDateForSheet', () => {
 
 describe('findEntryByDate', () => {
   const entries = [
-    { date: '2026/02/01', meetingNumber: 256, worldName: 'World1', creator: 'Creator1', confirmed: true, worldUrl: '' },
-    { date: '2026/02/08', meetingNumber: 257, worldName: 'World2', creator: 'Creator2', confirmed: false, worldUrl: '' },
-    { date: '2026/02/15', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'World1', creator: 'Creator1', confirmed: true, worldUrl: '', worldDescription: '' },
+    { date: '2026/02/08', meetingNumber: 257, worldName: 'World2', creator: 'Creator2', confirmed: false, worldUrl: '', worldDescription: '' },
+    { date: '2026/02/15', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
   ];
 
   it('finds entry matching date', () => {
@@ -142,9 +163,9 @@ describe('findEntryByDate', () => {
 
 describe('deriveSkippedDates', () => {
   const entries = [
-    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
-    { date: '2026/02/01', meetingNumber: 256, worldName: 'World', creator: 'Creator', confirmed: true, worldUrl: '' },
-    { date: '2026/02/22', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
+    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'World', creator: 'Creator', confirmed: true, worldUrl: '', worldDescription: '' },
+    { date: '2026/02/22', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
   ];
 
   it('extracts dates with null meeting numbers', () => {
@@ -158,7 +179,7 @@ describe('deriveSkippedDates', () => {
 
   it('returns empty array when no skipped dates', () => {
     const noSkips = [
-      { date: '2026/02/01', meetingNumber: 256, worldName: 'W', creator: 'C', confirmed: true, worldUrl: '' },
+      { date: '2026/02/01', meetingNumber: 256, worldName: 'W', creator: 'C', confirmed: true, worldUrl: '', worldDescription: '' },
     ];
     expect(deriveSkippedDates(noSkips)).toEqual([]);
   });
@@ -166,13 +187,13 @@ describe('deriveSkippedDates', () => {
 
 describe('generateScheduleAnnouncement', () => {
   const entries = [
-    { date: '2025/12/21', meetingNumber: 253, worldName: 'W1', creator: 'C1', confirmed: true, worldUrl: '' },
-    { date: '2025/12/28', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
-    { date: '2026/01/04', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
-    { date: '2026/01/11', meetingNumber: 254, worldName: 'W2', creator: 'C2', confirmed: true, worldUrl: '' },
-    { date: '2026/01/18', meetingNumber: 255, worldName: 'W3', creator: 'C3', confirmed: true, worldUrl: '' },
-    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
-    { date: '2026/02/01', meetingNumber: 256, worldName: 'W4', creator: 'C4', confirmed: true, worldUrl: '' },
+    { date: '2025/12/21', meetingNumber: 253, worldName: 'W1', creator: 'C1', confirmed: true, worldUrl: '', worldDescription: '' },
+    { date: '2025/12/28', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
+    { date: '2026/01/04', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
+    { date: '2026/01/11', meetingNumber: 254, worldName: 'W2', creator: 'C2', confirmed: true, worldUrl: '', worldDescription: '' },
+    { date: '2026/01/18', meetingNumber: 255, worldName: 'W3', creator: 'C3', confirmed: true, worldUrl: '', worldDescription: '' },
+    { date: '2026/01/25', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
+    { date: '2026/02/01', meetingNumber: 256, worldName: 'W4', creator: 'C4', confirmed: true, worldUrl: '', worldDescription: '' },
   ];
 
   it('generates announcement starting from the next Sunday', () => {
@@ -229,7 +250,7 @@ describe('generateScheduleAnnouncement', () => {
 describe('generateDiscordWeeklyMessage', () => {
   it('確定済みエントリにはワールド名と作者を含む', () => {
     const entries = [
-      { date: '2026/03/29', meetingNumber: 262, worldName: '星空の回廊', creator: 'testuser', confirmed: true, worldUrl: '' },
+      { date: '2026/03/29', meetingNumber: 262, worldName: '星空の回廊', creator: 'testuser', confirmed: true, worldUrl: '', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).toContain('星空の回廊');
@@ -239,7 +260,7 @@ describe('generateDiscordWeeklyMessage', () => {
 
   it('確定済みでURLがある場合はURLを含む', () => {
     const entries = [
-      { date: '2026/03/29', meetingNumber: 262, worldName: '星空の回廊', creator: 'testuser', confirmed: true, worldUrl: 'https://vrchat.com/home/world/wrld_xxx' },
+      { date: '2026/03/29', meetingNumber: 262, worldName: '星空の回廊', creator: 'testuser', confirmed: true, worldUrl: 'https://vrchat.com/home/world/wrld_xxx', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).toContain('https://vrchat.com/home/world/wrld_xxx');
@@ -247,7 +268,7 @@ describe('generateDiscordWeeklyMessage', () => {
 
   it('確定済みでURLがない場合はURLリンク行を含まない', () => {
     const entries = [
-      { date: '2026/03/29', meetingNumber: 262, worldName: '星空の回廊', creator: 'testuser', confirmed: true, worldUrl: '' },
+      { date: '2026/03/29', meetingNumber: 262, worldName: '星空の回廊', creator: 'testuser', confirmed: true, worldUrl: '', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).not.toContain('🔗');
@@ -255,7 +276,7 @@ describe('generateDiscordWeeklyMessage', () => {
 
   it('未確定エントリには「まだ決まっていません」を含む', () => {
     const entries = [
-      { date: '2026/03/29', meetingNumber: 262, worldName: '', creator: '', confirmed: false, worldUrl: '' },
+      { date: '2026/03/29', meetingNumber: 262, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).toContain('まだ決まっていません');
@@ -263,7 +284,7 @@ describe('generateDiscordWeeklyMessage', () => {
 
   it('お休み（meetingNumber null）には「お休み」を含む', () => {
     const entries = [
-      { date: '2026/03/29', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '' },
+      { date: '2026/03/29', meetingNumber: null, worldName: '', creator: '', confirmed: false, worldUrl: '', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).toContain('お休み');
@@ -271,7 +292,7 @@ describe('generateDiscordWeeklyMessage', () => {
 
   it('該当エントリがない場合はその旨を伝える', () => {
     const entries = [
-      { date: '2026/04/05', meetingNumber: 263, worldName: 'W', creator: 'C', confirmed: true, worldUrl: '' },
+      { date: '2026/04/05', meetingNumber: 263, worldName: 'W', creator: 'C', confirmed: true, worldUrl: '', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).toContain('予定が見つかりません');
@@ -279,7 +300,7 @@ describe('generateDiscordWeeklyMessage', () => {
 
   it('水曜から次の日曜を正しく計算する', () => {
     const entries = [
-      { date: '2026/03/29', meetingNumber: 262, worldName: 'テストワールド', creator: 'テスト作者', confirmed: true, worldUrl: '' },
+      { date: '2026/03/29', meetingNumber: 262, worldName: 'テストワールド', creator: 'テスト作者', confirmed: true, worldUrl: '', worldDescription: '' },
     ];
     const msg = generateDiscordWeeklyMessage(entries, new Date(2026, 2, 25));
     expect(msg).toContain('3/29');

--- a/src/lib/fetchSheetSchedule.ts
+++ b/src/lib/fetchSheetSchedule.ts
@@ -8,8 +8,10 @@ export interface ScheduleEntry {
   creator: string;
   /** スプレッドシートの「確定」チェックボックスの状態。TRUE なら確定済み。 */
   confirmed: boolean;
-  /** ワールドのURL（スプレッドシート7行目） */
+  /** ワールドのURL（スプレッドシート「url」行） */
   worldUrl: string;
+  /** ワールドの説明文（スプレッドシート「説明」行）。未記入時は空文字。 */
+  worldDescription: string;
 }
 
 export async function fetchScheduleFromSheet(): Promise<ScheduleEntry[]> {
@@ -84,6 +86,7 @@ export function parseScheduleCSV(csv: string): ScheduleEntry[] {
   // スプレッドシートの確定チェックボックス行（"TRUE" / "FALSE"）
   const confirmedRow = findRow('チェックが入っていたら確定分');
   const urlRow = findRow('url');
+  const descriptionRow = findRow('説明');
 
   if (!dateRow || !meetingRow) return [];
 
@@ -106,6 +109,7 @@ export function parseScheduleCSV(csv: string): ScheduleEntry[] {
       creator: creatorRow?.[i]?.trim() || '',
       confirmed: confirmedRow?.[i]?.trim().toUpperCase() === 'TRUE',
       worldUrl: urlRow?.[i]?.trim() || '',
+      worldDescription: descriptionRow?.[i]?.trim() || '',
     });
   }
 

--- a/src/lib/fetchVRChatWorld.test.ts
+++ b/src/lib/fetchVRChatWorld.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { extractVRChatWorldId } from './fetchVRChatWorld';
+
+describe('extractVRChatWorldId', () => {
+  it('標準的なVRChat URLからワールドIDを抽出する', () => {
+    const url = 'https://vrchat.com/home/world/wrld_12345678-1234-1234-1234-123456789abc';
+    expect(extractVRChatWorldId(url)).toBe('wrld_12345678-1234-1234-1234-123456789abc');
+  });
+
+  it('vrchat.com 以外のURLは null を返す', () => {
+    expect(extractVRChatWorldId('https://example.com/world/wrld_abc')).toBeNull();
+  });
+
+  it('ワールドID形式でないURLは null を返す', () => {
+    expect(extractVRChatWorldId('https://vrchat.com/home/user/usr_abc')).toBeNull();
+  });
+
+  it('空文字は null を返す', () => {
+    expect(extractVRChatWorldId('')).toBeNull();
+  });
+});

--- a/src/lib/fetchVRChatWorld.ts
+++ b/src/lib/fetchVRChatWorld.ts
@@ -1,0 +1,63 @@
+/**
+ * VRChat API からワールド情報を取得するユーティリティ。
+ *
+ * 背景: スプレッドシートのURL欄に記録された VRChat ワールドURLから
+ * ワールドの説明文・サムネイル等を取得し、画面に表示する。
+ * VRChat API は認証が必要なため、ブラウザから直接アクセスできない場合がある。
+ * その際は null を返してフォールバック表示に任せる。
+ */
+
+export interface VRChatWorldInfo {
+  /** ワールド名（スプレッドシートの値と一致確認用） */
+  name: string;
+  /** ワールドの説明文 */
+  description: string;
+  /** サムネイル画像URL */
+  imageUrl: string;
+  /** 作者の表示名 */
+  authorName: string;
+}
+
+/**
+ * VRChat ワールドURL からワールドIDを抽出する。
+ * 対応URL形式: https://vrchat.com/home/world/wrld_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ *
+ * 削除判断: fetchVRChatWorldInfo が不要になれば一緒に削除可能。
+ */
+export function extractVRChatWorldId(url: string): string | null {
+  const match = url.match(/vrchat\.com\/home\/world\/(wrld_[a-zA-Z0-9-]+)/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * VRChat API からワールド情報を取得する。
+ *
+ * VRChat API (api.vrchat.cloud) は認証Cookie が必要。
+ * credentials: 'include' で VRChat ウェブのセッションを利用できる場合がある。
+ * CORS またはセッション未ログイン時は null を返す（呼び出し元が適切に処理すること）。
+ *
+ * 呼び出し元: src/hooks/useTweetState.ts (thisWeekEntry.worldUrl 変化時)
+ */
+export async function fetchVRChatWorldInfo(worldId: string): Promise<VRChatWorldInfo | null> {
+  try {
+    const res = await fetch(
+      `https://api.vrchat.cloud/api/1/worlds/${worldId}`,
+      {
+        // VRChat ウェブでログイン済みであれば Cookie が送信される
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      name: data.name ?? '',
+      description: data.description ?? '',
+      imageUrl: data.imageUrl ?? '',
+      authorName: data.authorName ?? '',
+    };
+  } catch {
+    // CORS エラー・ネットワークエラー等はすべて null で返す
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds support for displaying world descriptions from both the Google Sheet and the VRChat API. It introduces a new utility module to fetch world information from VRChat's API and integrates it into the UI to show detailed world information for the upcoming week's event.

## Key Changes

- **Added `worldDescription` field to `ScheduleEntry`**: Extended the schedule entry interface to include world descriptions parsed from the "説明" (description) row in the spreadsheet
- **New VRChat API utility module** (`fetchVRChatWorld.ts`): 
  - `extractVRChatWorldId()`: Extracts world ID from VRChat world URLs
  - `fetchVRChatWorldInfo()`: Fetches world details (name, description, image, author) from VRChat API with proper error handling for CORS and authentication issues
- **Enhanced `useTweetState` hook**: 
  - Added state management for VRChat world info and loading status
  - Implemented `useEffect` to automatically fetch world details when the current week's world URL changes
  - Exposed `thisWeekEntry`, `vrchatWorldInfo`, and `isVrchatWorldLoading` to consumers
- **Updated UI in `App.tsx`**: 
  - Added a new "今週のワールド詳細" (This Week's World Details) section
  - Displays world URL as a clickable link
  - Shows VRChat API-fetched description with loading state
  - Falls back to spreadsheet description if API fetch fails
  - Uses appropriate icons (ExternalLink, FileText) for visual clarity
- **Comprehensive test coverage**: Added tests for CSV parsing with descriptions and VRChat world ID extraction

## Implementation Details

- VRChat API calls use `credentials: 'include'` to leverage existing browser sessions, gracefully returning `null` on CORS or authentication failures
- Description display follows a priority order: VRChat API description → spreadsheet description → nothing
- All existing tests updated to include the new `worldDescription` field in test fixtures

https://claude.ai/code/session_014wkkXq9N4myZPiDNtnCJGf