### PR TITLE
feat: VRChat API 呼び出しを Netlify Function プロキシ経由にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Claude Code worktrees (project rule: parallel work goes here)
+.claude/worktrees/
+# PR self-review counter (per .claude/rules/pr-self-review.md)
+.claude/.pr-review-count
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/netlify/functions/vrchat-world.ts
+++ b/netlify/functions/vrchat-world.ts
@@ -1,0 +1,66 @@
+/**
+ * VRChat API ワールド情報プロキシ。
+ *
+ * 背景: ブラウザから https://vrchat.com/api/1/worlds/{id} を直接呼ぶと
+ * - CORS で弾かれる（vrchat.com オリジンにしか Access-Control-Allow-Origin が付かない）
+ * - ブラウザは User-Agent を上書きできないが、VRChat API は適切な UA がないと 403 を返す
+ * という二重の理由でレスポンスを読めない。同一オリジンのこの Netlify Function を挟むことで
+ * サーバーサイドから UA 付きで呼び、結果をフロントへ返す。
+ *
+ * 呼び出し元: src/lib/fetchVRChatWorld.ts
+ * デプロイ先: /.netlify/functions/vrchat-world
+ */
+
+const WORLD_ID_PATTERN = /^wrld_[a-zA-Z0-9-]+$/;
+
+// VRChat 非公式 API では連絡先（リポジトリ URL）を UA に載せるのが慣例
+const USER_AGENT =
+  'tweet-validator-for-achakai/1.0 (+https://github.com/tktcorporation/tweet-validator-for-achakai)';
+
+export default async (req: Request): Promise<Response> => {
+  const worldId = new URL(req.url).searchParams.get('id');
+
+  if (!worldId || !WORLD_ID_PATTERN.test(worldId)) {
+    return jsonResponse({ error: 'invalid world id' }, 400);
+  }
+
+  try {
+    const upstream = await fetch(`https://vrchat.com/api/1/worlds/${worldId}`, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!upstream.ok) {
+      return jsonResponse(
+        { error: 'upstream error', status: upstream.status },
+        upstream.status,
+      );
+    }
+
+    const data = await upstream.json();
+    return jsonResponse(data, 200, {
+      // ワールド情報は頻繁には変わらないため 1 時間ブラウザ/エッジキャッシュ
+      'Cache-Control': 'public, max-age=3600',
+    });
+  } catch {
+    // ネットワーク障害・DNS 失敗等。呼び出し元は 502 を !ok として null フォールバックする。
+    // 内部エラー詳細はレスポンスに載せない（インフラ情報の漏洩防止）
+    return jsonResponse({ error: 'fetch failed' }, 502);
+  }
+};
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      ...extraHeaders,
+    },
+  });
+}

--- a/src/lib/fetchVRChatWorld.test.ts
+++ b/src/lib/fetchVRChatWorld.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { extractVRChatWorldId } from './fetchVRChatWorld';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractVRChatWorldId, fetchVRChatWorldInfo } from './fetchVRChatWorld';
 
 describe('extractVRChatWorldId', () => {
   it('標準的なVRChat URLからワールドIDを抽出する', () => {
@@ -24,5 +24,69 @@ describe('extractVRChatWorldId', () => {
 
   it('空文字は null を返す', () => {
     expect(extractVRChatWorldId('')).toBeNull();
+  });
+});
+
+describe('fetchVRChatWorldInfo', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('Netlify Function 経由でワールド情報を取得する', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: 'Test World',
+          description: 'desc',
+          imageUrl: 'https://example.com/img.png',
+          authorName: 'Author',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    const info = await fetchVRChatWorldInfo('wrld_abc-123');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/.netlify/functions/vrchat-world?id=wrld_abc-123',
+      expect.any(Object),
+    );
+    expect(info).toEqual({
+      name: 'Test World',
+      description: 'desc',
+      imageUrl: 'https://example.com/img.png',
+      authorName: 'Author',
+    });
+  });
+
+  it('Function が非 2xx を返したら null', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response('', { status: 502 }),
+    );
+    expect(await fetchVRChatWorldInfo('wrld_abc')).toBeNull();
+  });
+
+  it('fetch が throw したら null', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new TypeError('network'));
+    expect(await fetchVRChatWorldInfo('wrld_abc')).toBeNull();
+  });
+
+  it('ワールドIDは URL エンコードされる', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    await fetchVRChatWorldInfo('wrld_abc def');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/.netlify/functions/vrchat-world?id=wrld_abc%20def',
+      expect.any(Object),
+    );
   });
 });

--- a/src/lib/fetchVRChatWorld.ts
+++ b/src/lib/fetchVRChatWorld.ts
@@ -3,8 +3,9 @@
  *
  * 背景: スプレッドシートのURL欄に記録された VRChat ワールドURLから
  * ワールドの説明文・サムネイル等を取得し、画面に表示する。
- * VRChat API は認証が必要なため、ブラウザから直接アクセスできない場合がある。
- * その際は null を返してフォールバック表示に任せる。
+ * ブラウザから VRChat API を直接叩くと CORS と UA 要件で失敗するため、
+ * 同一オリジンの Netlify Function (netlify/functions/vrchat-world.ts) 経由で呼ぶ。
+ * 取得に失敗した場合は null を返し、呼び出し元はシート記載の説明にフォールバックする。
  */
 
 export interface VRChatWorldInfo {
@@ -32,9 +33,9 @@ export function extractVRChatWorldId(url: string): string | null {
 /**
  * VRChat API からワールド情報を取得する。
  *
- * VRChat API (api.vrchat.cloud) は認証Cookie が必要。
- * credentials: 'include' で VRChat ウェブのセッションを利用できる場合がある。
- * CORS またはセッション未ログイン時は null を返す（呼び出し元が適切に処理すること）。
+ * 実体のリクエストは同一オリジンの Netlify Function が行う
+ * （直接叩くと CORS/UA 要件で失敗するため。詳細は netlify/functions/vrchat-world.ts）。
+ * プロキシが 4xx/5xx を返すか、ローカル dev 等で Function が存在しない場合は null を返す。
  *
  * 呼び出し元: src/hooks/useTweetState.ts (thisWeekEntry.worldUrl 変化時)
  */
@@ -43,12 +44,8 @@ export async function fetchVRChatWorldInfo(
 ): Promise<VRChatWorldInfo | null> {
   try {
     const res = await fetch(
-      `https://api.vrchat.cloud/api/1/worlds/${worldId}`,
-      {
-        // VRChat ウェブでログイン済みであれば Cookie が送信される
-        credentials: 'include',
-        headers: { Accept: 'application/json' },
-      },
+      `/.netlify/functions/vrchat-world?id=${encodeURIComponent(worldId)}`,
+      { headers: { Accept: 'application/json' } },
     );
     if (!res.ok) return null;
     const data = await res.json();
@@ -59,7 +56,7 @@ export async function fetchVRChatWorldInfo(
       authorName: data.authorName ?? '',
     };
   } catch {
-    // CORS エラー・ネットワークエラー等はすべて null で返す
+    // Function 未デプロイ/ネットワーク障害等はすべて null で返し、シート値へフォールバック
     return null;
   }
 }


### PR DESCRIPTION
## 概要

ブラウザから VRChat API を直接呼べない 2 つの問題を、同一オリジンの Netlify Function で回避する。

- **CORS**: `vrchat.com` オリジンにのみ `Access-Control-Allow-Origin` が返されるので、他オリジン（本アプリの Netlify ドメイン）からは response を読めない。
- **User-Agent 要件**: VRChat API はデフォルト UA や短い UA に 403 を返すが、ブラウザ fetch は forbidden header の仕様で UA を上書きできない。

サーバーサイドの Netlify Function を挟めば両方クリアできる。失敗時は既存の null フォールバック経路でシート記載の説明を表示する。

## 変更内容

- **NEW** \`netlify/functions/vrchat-world.ts\`
  - \`?id=wrld_...\` を受け取り、正規表現で入力検証（\`^wrld_[a-zA-Z0-9-]+$\`）
  - \`https://vrchat.com/api/1/worlds/{id}\` を UA 付きで呼ぶ（UA にはリポジトリ URL を載せて連絡先にする）
  - 成功時は JSON をそのまま返し \`Cache-Control: public, max-age=3600\` で 1 時間キャッシュ
  - エラーは 400（不正 id）/ upstream ステータス透過 / 502（fetch throw）
  - 内部エラー詳細はレスポンスボディに載せない（インフラ情報漏洩防止）
- **MOD** \`src/lib/fetchVRChatWorld.ts\`
  - fetch 先を \`/.netlify/functions/vrchat-world?id=...\` に変更
  - \`credentials: 'include'\` を削除（同一オリジン、認証 Cookie 不要）
  - JSDoc を新しい構成に合わせて更新
- **MOD** \`src/lib/fetchVRChatWorld.test.ts\`
  - \`fetchVRChatWorldInfo\` の happy path / 非 2xx / throw / URL エンコードの 4 テストを追加
- **MOD** \`.gitignore\`
  - \`.claude/worktrees/\` と \`.claude/.pr-review-count\` を追加

## レビュー結果

### 修正した指摘
- 502 レスポンスで \`String(e)\` を返していた点（DNS/内部ネットワーク情報漏洩の可能性）→ \`{ error: 'fetch failed' }\` のみ返すように修正

### 見つけたが修正しなかったもの
- **upstream status の透過**（404/403/502 等をそのまま返す）— クライアントは \`res.ok\` しか見ておらず、ステータス透過は将来の細粒度ハンドリング拡張のために有用。現状の挙動と矛盾しないため維持。
- **\`{ status: upstream.status }\` の body 露出** — VRChat の公開 HTTP ステータスを返しているだけで機密ではなく、フロントは body を無視する。修正しても見えている挙動が変わらないため維持。

## Test plan

- [x] \`pnpm exec biome check .\` / \`pnpm exec biome format .\` pass
- [x] \`pnpm exec vitest run\` → 65 tests pass（新規追加 4 テスト含む）
- [x] \`pnpm exec vite build\` 成功
- [x] \`tsc --noEmit\` で \`netlify/functions/vrchat-world.ts\` が型エラーなし
- [x] セルフレビュー 2 回（code-reviewer agent）
- [ ] デプロイ後、本番環境で \`/.netlify/functions/vrchat-world?id=wrld_...\` が 200 を返し、フロントでワールド説明が描画されることを確認
- [ ] \`pnpm dev\`（Vite のみ）では Function が 404 となり、既存のシート説明フォールバックが動作することを確認

## 備考

- ローカルで Function も動かしたい場合は \`netlify dev\` を使う（このリポジトリに CLI 設定はまだ無いので別 PR で追加検討）
- Netlify ビルド Node が 18.x、\`package.json\` engines は \`>=22.12.0\` のズレがあるが、本関数は Node 18 の native fetch で動く範囲で書いている。ランタイムバージョン更新は別タスク。