### PR TITLE
feat: 毎週日曜のVRChatグループインスタンス状況をDiscord通知

### DIFF
--- a/.github/workflows/discord-group-instances-notify.yml
+++ b/.github/workflows/discord-group-instances-notify.yml
@@ -29,4 +29,3 @@ jobs:
           VRCHAT_USER_ID: ${{ secrets.VRCHAT_USER_ID }}
           VRCHAT_GROUP_ID: ${{ secrets.VRCHAT_GROUP_ID }}
           VRCHAT_AUTH_COOKIE: ${{ secrets.VRCHAT_AUTH_COOKIE }}
-          VRCHAT_TWOFA_COOKIE: ${{ secrets.VRCHAT_TWOFA_COOKIE }}

--- a/.github/workflows/discord-group-instances-notify.yml
+++ b/.github/workflows/discord-group-instances-notify.yml
@@ -1,0 +1,32 @@
+name: Discord Group Instances Notify
+
+on:
+  schedule:
+    # 毎週日曜 15:45 JST (= 06:45 UTC)
+    - cron: '45 6 * * 0'
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Send Discord notification
+        run: npx tsx scripts/discord-group-instances-notify.ts
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VRCHAT_USER_ID: ${{ secrets.VRCHAT_USER_ID }}
+          VRCHAT_GROUP_ID: ${{ secrets.VRCHAT_GROUP_ID }}
+          VRCHAT_AUTH_COOKIE: ${{ secrets.VRCHAT_AUTH_COOKIE }}
+          VRCHAT_TWOFA_COOKIE: ${{ secrets.VRCHAT_TWOFA_COOKIE }}

--- a/scripts/discord-group-instances-notify.ts
+++ b/scripts/discord-group-instances-notify.ts
@@ -48,7 +48,13 @@ async function main() {
   const response = await fetch(webhookUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content: message }),
+    // message は VRChat の world / instance 名 (ユーザー生成) を含むため、
+    // `@everyone` などが混入しても実際のメンションが飛ばないよう
+    // allowed_mentions を空にしてパースを無効化する。
+    body: JSON.stringify({
+      content: message,
+      allowed_mentions: { parse: [] },
+    }),
   });
 
   if (!response.ok) {

--- a/scripts/discord-group-instances-notify.ts
+++ b/scripts/discord-group-instances-notify.ts
@@ -1,0 +1,69 @@
+/**
+ * Discord グループインスタンス状況通知スクリプト。
+ *
+ * 背景: 毎週日曜 15:45 JST に、あ茶会グループが現在立てている
+ *   ワールドとインスタンス人数を Discord に通知する。
+ *   VRChat API は認証必須のため Cookie を GitHub Secrets から渡す。
+ *
+ * 実行方法: npx tsx scripts/discord-group-instances-notify.ts
+ * 環境変数（全て必須）:
+ *   - DISCORD_WEBHOOK_URL
+ *   - VRCHAT_USER_ID       (usr_... 形式。bot アカウントの ID)
+ *   - VRCHAT_GROUP_ID      (grp_... 形式)
+ *   - VRCHAT_AUTH_COOKIE   (authcookie_... の値のみ)
+ *   - VRCHAT_TWOFA_COOKIE  (twoFactorAuth JWT の値のみ、~30日で失効)
+ */
+
+import {
+  fetchGroupInstances,
+  formatGroupInstancesMessage,
+} from '../src/lib/fetchGroupInstances.js';
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`${name} が設定されていません`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main() {
+  const webhookUrl = requireEnv('DISCORD_WEBHOOK_URL');
+  const userId = requireEnv('VRCHAT_USER_ID');
+  const groupId = requireEnv('VRCHAT_GROUP_ID');
+  const authCookie = requireEnv('VRCHAT_AUTH_COOKIE');
+  const twoFactorAuthCookie = requireEnv('VRCHAT_TWOFA_COOKIE');
+
+  console.log('VRChat グループインスタンス一覧を取得中...');
+  const instances = await fetchGroupInstances({
+    userId,
+    groupId,
+    authCookie,
+    twoFactorAuthCookie,
+  });
+  console.log(`${instances.length} 件のインスタンスを取得`);
+
+  const message = formatGroupInstancesMessage(instances);
+  console.log('送信メッセージ:');
+  console.log(message);
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: message }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.error(`Discord webhook 送信失敗: ${response.status} ${body}`);
+    process.exit(1);
+  }
+
+  console.log('Discord に通知を送信しました');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/discord-group-instances-notify.ts
+++ b/scripts/discord-group-instances-notify.ts
@@ -11,7 +11,6 @@
  *   - VRCHAT_USER_ID       (usr_... 形式。bot アカウントの ID)
  *   - VRCHAT_GROUP_ID      (grp_... 形式)
  *   - VRCHAT_AUTH_COOKIE   (authcookie_... の値のみ)
- *   - VRCHAT_TWOFA_COOKIE  (twoFactorAuth JWT の値のみ、~30日で失効)
  */
 
 import {
@@ -33,14 +32,12 @@ async function main() {
   const userId = requireEnv('VRCHAT_USER_ID');
   const groupId = requireEnv('VRCHAT_GROUP_ID');
   const authCookie = requireEnv('VRCHAT_AUTH_COOKIE');
-  const twoFactorAuthCookie = requireEnv('VRCHAT_TWOFA_COOKIE');
 
   console.log('VRChat グループインスタンス一覧を取得中...');
   const instances = await fetchGroupInstances({
     userId,
     groupId,
     authCookie,
-    twoFactorAuthCookie,
   });
   console.log(`${instances.length} 件のインスタンスを取得`);
 

--- a/src/lib/fetchGroupInstances.test.ts
+++ b/src/lib/fetchGroupInstances.test.ts
@@ -20,27 +20,35 @@ describe('fetchGroupInstances', () => {
     userId: 'usr_abc',
     groupId: 'grp_xyz',
     authCookie: 'authcookie_val',
-    twoFactorAuthCookie: 'twofa_val',
   };
 
-  it('VRChat API を Cookie 付きで叩き、必要フィールドを抽出する', async () => {
+  // 実 API のレスポンス形状を再現した mock helper。
+  // 2026-04 時点で VRChat API が返す top-level は `{fetchedAt, instances: [...]}`
+  // で、各 instance は worldId / world / displayName / name / userCount / capacity
+  // / region / n_users などがフラットに並ぶ。
+  const realResponse = (instances: unknown[]) => ({
+    fetchedAt: '2026-04-19T06:45:00Z',
+    instances,
+  });
+
+  it('VRChat API を auth Cookie 付きで叩き、実レスポンス形式から必要フィールドを抽出する', async () => {
     const mockFetch = vi.mocked(globalThis.fetch);
     mockFetch.mockResolvedValueOnce(
       new Response(
-        JSON.stringify([
-          {
-            fetchedAt: '2026-04-19T06:45:00Z',
-            instance: {
+        JSON.stringify(
+          realResponse([
+            {
               worldId: 'wrld_1',
               displayName: 'Untitled Tea Party',
               name: '51786',
               userCount: 18,
+              n_users: 18,
               capacity: 64,
               region: 'jp',
               world: { id: 'wrld_1', name: 'Ever-changing City v5' },
             },
-          },
-        ]),
+          ]),
+        ),
         { status: 200 },
       ),
     );
@@ -48,10 +56,10 @@ describe('fetchGroupInstances', () => {
     const result = await fetchGroupInstances(baseOptions);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://vrchat.com/api/1/users/usr_abc/instances/groups/grp_xyz',
+      'https://api.vrchat.cloud/api/1/users/usr_abc/instances/groups/grp_xyz',
       expect.objectContaining({
         headers: expect.objectContaining({
-          Cookie: 'auth=authcookie_val; twoFactorAuth=twofa_val',
+          Cookie: 'auth=authcookie_val',
         }),
       }),
     );
@@ -68,35 +76,53 @@ describe('fetchGroupInstances', () => {
     ]);
   });
 
-  it('instance.worldId が無くても entry.world.id からフォールバック取得する', async () => {
+  it('instances が空配列なら空リストを返す', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(realResponse([])), { status: 200 }),
+    );
+    expect(await fetchGroupInstances(baseOptions)).toEqual([]);
+  });
+
+  it('userCount が無い場合は n_users にフォールバックする', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify(
+          realResponse([
+            {
+              worldId: 'wrld_x',
+              name: '1',
+              n_users: 7,
+              capacity: 16,
+              region: 'us',
+              world: { id: 'wrld_x', name: 'X' },
+            },
+          ]),
+        ),
+        { status: 200 },
+      ),
+    );
+    const [inst] = await fetchGroupInstances(baseOptions);
+    expect(inst.userCount).toBe(7);
+  });
+
+  it('top-level が配列の古い形式もフォールバックで受け入れる', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(
         JSON.stringify([
           {
-            world: { id: 'wrld_from_entry', name: 'From Entry World' },
-            instance: {
-              name: '42',
-              userCount: 3,
-              capacity: 32,
-              region: 'eu',
-            },
+            worldId: 'wrld_legacy',
+            name: '1',
+            userCount: 1,
+            capacity: 16,
+            region: 'jp',
+            world: { id: 'wrld_legacy', name: 'Legacy' },
           },
         ]),
         { status: 200 },
       ),
     );
     const result = await fetchGroupInstances(baseOptions);
-    expect(result).toEqual<GroupInstance[]>([
-      {
-        worldId: 'wrld_from_entry',
-        worldName: 'From Entry World',
-        displayName: '',
-        name: '42',
-        userCount: 3,
-        capacity: 32,
-        region: 'eu',
-      },
-    ]);
+    expect(result[0].worldId).toBe('wrld_legacy');
   });
 
   it('Cookie 値にセミコロンが含まれていたら例外を投げる', async () => {
@@ -110,18 +136,18 @@ describe('fetchGroupInstances', () => {
   it('worldId を持たないエントリは除外する', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(
-        JSON.stringify([
-          { instance: { name: '1', userCount: 1 } },
-          {
-            instance: {
+        JSON.stringify(
+          realResponse([
+            { name: '1', userCount: 1 },
+            {
               worldId: 'wrld_ok',
               name: '2',
               userCount: 2,
               capacity: 16,
               world: { id: 'wrld_ok', name: 'OK World' },
             },
-          },
-        ]),
+          ]),
+        ),
         { status: 200 },
       ),
     );
@@ -139,18 +165,20 @@ describe('fetchGroupInstances', () => {
     await expect(fetchGroupInstances(baseOptions)).rejects.toThrow(/401/);
   });
 
-  it('配列以外が返ったら例外を投げる', async () => {
+  it('想定外の形状（配列でも instances キーでもない）は例外を投げる', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ error: 'nope' }), { status: 200 }),
     );
 
-    await expect(fetchGroupInstances(baseOptions)).rejects.toThrow(/non-array/);
+    await expect(fetchGroupInstances(baseOptions)).rejects.toThrow(
+      /unexpected response shape/,
+    );
   });
 
   it('ユーザーID・グループIDを URL エンコードする', async () => {
     const mockFetch = vi.mocked(globalThis.fetch);
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify([]), { status: 200 }),
+      new Response(JSON.stringify(realResponse([])), { status: 200 }),
     );
 
     await fetchGroupInstances({
@@ -160,7 +188,7 @@ describe('fetchGroupInstances', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://vrchat.com/api/1/users/usr%20a%2Fb/instances/groups/grp%20x',
+      'https://api.vrchat.cloud/api/1/users/usr%20a%2Fb/instances/groups/grp%20x',
       expect.any(Object),
     );
   });

--- a/src/lib/fetchGroupInstances.test.ts
+++ b/src/lib/fetchGroupInstances.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type GroupInstance,
+  fetchGroupInstances,
+  formatGroupInstancesMessage,
+} from './fetchGroupInstances';
+
+describe('fetchGroupInstances', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const baseOptions = {
+    userId: 'usr_abc',
+    groupId: 'grp_xyz',
+    authCookie: 'authcookie_val',
+    twoFactorAuthCookie: 'twofa_val',
+  };
+
+  it('VRChat API を Cookie 付きで叩き、必要フィールドを抽出する', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          {
+            fetchedAt: '2026-04-19T06:45:00Z',
+            instance: {
+              worldId: 'wrld_1',
+              displayName: 'Untitled Tea Party',
+              name: '51786',
+              userCount: 18,
+              capacity: 64,
+              region: 'jp',
+              world: { id: 'wrld_1', name: 'Ever-changing City v5' },
+            },
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+
+    const result = await fetchGroupInstances(baseOptions);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://vrchat.com/api/1/users/usr_abc/instances/groups/grp_xyz',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: 'auth=authcookie_val; twoFactorAuth=twofa_val',
+        }),
+      }),
+    );
+    expect(result).toEqual<GroupInstance[]>([
+      {
+        worldId: 'wrld_1',
+        worldName: 'Ever-changing City v5',
+        displayName: 'Untitled Tea Party',
+        name: '51786',
+        userCount: 18,
+        capacity: 64,
+        region: 'jp',
+      },
+    ]);
+  });
+
+  it('instance.worldId が無くても entry.world.id からフォールバック取得する', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          {
+            world: { id: 'wrld_from_entry', name: 'From Entry World' },
+            instance: {
+              name: '42',
+              userCount: 3,
+              capacity: 32,
+              region: 'eu',
+            },
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+    const result = await fetchGroupInstances(baseOptions);
+    expect(result).toEqual<GroupInstance[]>([
+      {
+        worldId: 'wrld_from_entry',
+        worldName: 'From Entry World',
+        displayName: '',
+        name: '42',
+        userCount: 3,
+        capacity: 32,
+        region: 'eu',
+      },
+    ]);
+  });
+
+  it('Cookie 値にセミコロンが含まれていたら例外を投げる', async () => {
+    await expect(
+      fetchGroupInstances({ ...baseOptions, authCookie: 'bad;value' }),
+    ).rejects.toThrow(/Cookie value must not contain/);
+    // セミコロンチェックは fetch 前で行う
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it('worldId を持たないエントリは除外する', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          { instance: { name: '1', userCount: 1 } },
+          {
+            instance: {
+              worldId: 'wrld_ok',
+              name: '2',
+              userCount: 2,
+              capacity: 16,
+              world: { id: 'wrld_ok', name: 'OK World' },
+            },
+          },
+        ]),
+        { status: 200 },
+      ),
+    );
+
+    const result = await fetchGroupInstances(baseOptions);
+    expect(result).toHaveLength(1);
+    expect(result[0].worldId).toBe('wrld_ok');
+  });
+
+  it('非 2xx は例外を投げる', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response('unauthorized', { status: 401 }),
+    );
+
+    await expect(fetchGroupInstances(baseOptions)).rejects.toThrow(/401/);
+  });
+
+  it('配列以外が返ったら例外を投げる', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'nope' }), { status: 200 }),
+    );
+
+    await expect(fetchGroupInstances(baseOptions)).rejects.toThrow(/non-array/);
+  });
+
+  it('ユーザーID・グループIDを URL エンコードする', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+
+    await fetchGroupInstances({
+      ...baseOptions,
+      userId: 'usr a/b',
+      groupId: 'grp x',
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://vrchat.com/api/1/users/usr%20a%2Fb/instances/groups/grp%20x',
+      expect.any(Object),
+    );
+  });
+});
+
+describe('formatGroupInstancesMessage', () => {
+  const fixed = new Date('2026-04-19T06:45:00Z');
+
+  it('0 件なら「0件でした」を含む', () => {
+    const msg = formatGroupInstancesMessage([], fixed);
+    expect(msg).toContain('0件でした');
+    expect(msg).toContain('<t:');
+  });
+
+  it('複数インスタンスをワールド別にグルーピングする', () => {
+    const instances: GroupInstance[] = [
+      {
+        worldId: 'wrld_1',
+        worldName: 'Ever-changing City v5',
+        displayName: 'Untitled Tea Party',
+        name: '51786',
+        userCount: 18,
+        capacity: 64,
+        region: 'jp',
+      },
+      {
+        worldId: 'wrld_1',
+        worldName: 'Ever-changing City v5',
+        displayName: '',
+        name: '33690',
+        userCount: 21,
+        capacity: 64,
+        region: 'jp',
+      },
+      {
+        worldId: 'wrld_2',
+        worldName: 'Another World',
+        displayName: '',
+        name: '99999',
+        userCount: 5,
+        capacity: 32,
+        region: 'us',
+      },
+    ];
+
+    const msg = formatGroupInstancesMessage(instances, fixed);
+
+    expect(msg).toContain(
+      'Ever-changing City v5 — 2 インスタンス / 合計 39 人',
+    );
+    expect(msg).toContain('• Untitled Tea Party — 18/64 (JP)');
+    expect(msg).toContain('• #33690 — 21/64 (JP)');
+    expect(msg).toContain('Another World — 1 インスタンス / 合計 5 人');
+    expect(msg).toContain('• #99999 — 5/32 (US)');
+  });
+
+  it('displayName が空なら #name をフォールバックに使う', () => {
+    const msg = formatGroupInstancesMessage(
+      [
+        {
+          worldId: 'wrld_1',
+          worldName: 'W',
+          displayName: '',
+          name: '12345',
+          userCount: 1,
+          capacity: 16,
+          region: 'jp',
+        },
+      ],
+      fixed,
+    );
+    expect(msg).toContain('• #12345');
+  });
+
+  it('Discord タイムスタンプ記法を含む', () => {
+    const msg = formatGroupInstancesMessage([], fixed);
+    const unix = Math.floor(fixed.getTime() / 1000);
+    expect(msg).toContain(`<t:${unix}:F>`);
+  });
+
+  it('Discord 2000文字制限を超えたら省略マーカー付きで切り詰める', () => {
+    // 20ワールド × 各10インスタンスで確実に 2000 超
+    const instances: GroupInstance[] = [];
+    for (let w = 0; w < 20; w++) {
+      for (let i = 0; i < 10; i++) {
+        instances.push({
+          worldId: `wrld_${w}`,
+          worldName: `World Name Number ${w}`,
+          displayName: `Some Long Instance Display Name ${w}-${i}`,
+          name: String(10000 + i),
+          userCount: 10,
+          capacity: 64,
+          region: 'jp',
+        });
+      }
+    }
+    const msg = formatGroupInstancesMessage(instances, fixed);
+    expect([...msg].length).toBeLessThanOrEqual(2000);
+    expect(msg).toMatch(/…\(省略\)$/);
+  });
+});

--- a/src/lib/fetchGroupInstances.ts
+++ b/src/lib/fetchGroupInstances.ts
@@ -36,21 +36,17 @@ export interface GroupInstance {
 }
 
 /**
- * VRChat API のレスポンスから必要フィールドを抽出する。
+ * instances 配列の 1 要素から必要フィールドを抽出する。
  *
- * API は `{ fetchedAt, instance: {...}, world: {...} }` の配列を返す仕様だが、
- * 非公式 API のため一部フィールドが省略される可能性を考慮してオプショナル扱い。
+ * 実 API の各要素はフラット形式: `{ worldId, world: {...}, displayName, name,
+ * userCount, n_users, capacity, region, ... }`。非公式 API のため一部フィールドが
+ * 欠ける可能性を考慮してオプショナル扱いし、worldId が取れない要素は null で除外。
  */
 function extractInstance(raw: unknown): GroupInstance | null {
   if (!raw || typeof raw !== 'object') return null;
-  const entry = raw as Record<string, unknown>;
+  const inst = raw as Record<string, unknown>;
 
-  const inst = (entry.instance as Record<string, unknown> | undefined) ?? entry;
-  if (!inst || typeof inst !== 'object') return null;
-
-  const worldObj =
-    (entry.world as Record<string, unknown> | undefined) ??
-    (inst.world as Record<string, unknown> | undefined);
+  const worldObj = inst.world as Record<string, unknown> | undefined;
 
   const worldId =
     (typeof inst.worldId === 'string' ? inst.worldId : '') ||
@@ -83,40 +79,44 @@ function extractInstance(raw: unknown): GroupInstance | null {
  *
  * - userId / groupId: `usr_...` / `grp_...` 形式の生ID
  * - authCookie: Cookie 値本体のみ（`auth=` プレフィックスは不要。`authcookie_...` の文字列）
- * - twoFactorAuthCookie: Cookie 値本体のみ（`twoFactorAuth=` プレフィックスは不要）
- *   JWT 形式で有効期限 ~30日。期限切れで 401 になったら手動で更新する運用
+ *
+ * 実験により、この endpoint は `auth` Cookie 単独で 200 を返すことを確認済み。
+ * `twoFactorAuth` Cookie は付けても付けなくてもレスポンスが変わらないため、
+ * 運用を単純化するため要求しない（30日失効 JWT の管理を避ける）。
  */
 export interface FetchGroupInstancesOptions {
   userId: string;
   groupId: string;
   authCookie: string;
-  twoFactorAuthCookie: string;
 }
 
 /**
  * VRChat API から指定グループのインスタンス一覧を取得する。
  *
- * auth / twoFactorAuth Cookie は GitHub Secrets から渡す。twoFactorAuth は
- * 有効期限が約 30 日なので、期限切れで 401 になったら手動で更新する運用。
+ * auth Cookie は GitHub Secrets から渡す。
+ * レスポンスは `{ fetchedAt, instances: [...] }` のラッパー形式。
  */
 export async function fetchGroupInstances(
   options: FetchGroupInstancesOptions,
 ): Promise<GroupInstance[]> {
-  const { userId, groupId, authCookie, twoFactorAuthCookie } = options;
+  const { userId, groupId, authCookie } = options;
 
   // Cookie ヘッダ組み立て時にセミコロンが混入すると別の Cookie として解釈される。
   // Secrets の誤設定や仕様変更を早期検知するため、明示的にガードする。
-  if (authCookie.includes(';') || twoFactorAuthCookie.includes(';')) {
+  if (authCookie.includes(';')) {
     throw new Error('Cookie value must not contain ";"');
   }
 
-  const url = `https://vrchat.com/api/1/users/${encodeURIComponent(userId)}/instances/groups/${encodeURIComponent(groupId)}`;
+  // vrchat.com は api.vrchat.cloud へ 307 リダイレクトする。
+  // Node の fetch は cross-origin リダイレクト時に Cookie ヘッダを落とすため、
+  // リダイレクト先を直接叩く（ブラウザ DevTools でも同一ホストとして動く）。
+  const url = `https://api.vrchat.cloud/api/1/users/${encodeURIComponent(userId)}/instances/groups/${encodeURIComponent(groupId)}`;
 
   const res = await fetch(url, {
     headers: {
       'User-Agent': USER_AGENT,
       Accept: 'application/json',
-      Cookie: `auth=${authCookie}; twoFactorAuth=${twoFactorAuthCookie}`,
+      Cookie: `auth=${authCookie}`,
     },
   });
 
@@ -128,13 +128,27 @@ export async function fetchGroupInstances(
   }
 
   const data: unknown = await res.json();
-  if (!Array.isArray(data)) {
-    throw new Error('VRChat API returned non-array response');
+  const instancesArr = extractInstancesArray(data);
+  if (instancesArr === null) {
+    throw new Error('VRChat API returned unexpected response shape');
   }
 
-  return data
+  return instancesArr
     .map(extractInstance)
     .filter((i): i is GroupInstance => i !== null);
+}
+
+/**
+ * 実レスポンスは `{fetchedAt, instances: [...]}` のラッパー形式だが、
+ * VRChat 非公式 API の仕様変更に備えて top-level 配列形式もフォールバック許容する。
+ */
+function extractInstancesArray(data: unknown): unknown[] | null {
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === 'object') {
+    const instances = (data as Record<string, unknown>).instances;
+    if (Array.isArray(instances)) return instances;
+  }
+  return null;
 }
 
 /**

--- a/src/lib/fetchGroupInstances.ts
+++ b/src/lib/fetchGroupInstances.ts
@@ -1,0 +1,209 @@
+/**
+ * VRChat グループインスタンス一覧の取得 & Discord 向け整形。
+ *
+ * 背景: あ茶会グループが現在どのワールドで何個のインスタンスを
+ *   立てているか、各インスタンスに何人いるかを Discord に流したい。
+ *   `/api/1/users/{userId}/instances/groups/{groupId}` はユーザーの
+ *   グループ権限から見える instance 一覧を返す（要認証）。
+ *   ユーザーIDを指定しているのは「どのユーザーの視点で見える
+ *   インスタンスか」を決めるためで、ボット用アカウント固定でよい。
+ *
+ * 呼び出し元: scripts/discord-group-instances-notify.ts (GitHub Actions)
+ */
+
+const USER_AGENT =
+  'tweet-validator-for-achakai/1.0 (+https://github.com/tktcorporation/tweet-validator-for-achakai)';
+
+/**
+ * 整形処理で利用する最小限のインスタンス情報。
+ * VRChat API のレスポンスは膨大なため、必要なフィールドだけを抽出した型で扱う。
+ */
+export interface GroupInstance {
+  /** ワールド識別子 (wrld_...)。ワールドごとの集計キー */
+  worldId: string;
+  /** ワールド表示名。空文字なら worldId を表示フォールバック */
+  worldName: string;
+  /** インスタンスの displayName（オーナーが設定した名前）。空の場合は #name を表示 */
+  displayName: string;
+  /** インスタンス番号 (例: "51786")。displayName が空のときの表示に使う */
+  name: string;
+  /** 現在の人数 */
+  userCount: number;
+  /** 定員 */
+  capacity: number;
+  /** リージョン (jp/us/eu/...) */
+  region: string;
+}
+
+/**
+ * VRChat API のレスポンスから必要フィールドを抽出する。
+ *
+ * API は `{ fetchedAt, instance: {...}, world: {...} }` の配列を返す仕様だが、
+ * 非公式 API のため一部フィールドが省略される可能性を考慮してオプショナル扱い。
+ */
+function extractInstance(raw: unknown): GroupInstance | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const entry = raw as Record<string, unknown>;
+
+  const inst = (entry.instance as Record<string, unknown> | undefined) ?? entry;
+  if (!inst || typeof inst !== 'object') return null;
+
+  const worldObj =
+    (entry.world as Record<string, unknown> | undefined) ??
+    (inst.world as Record<string, unknown> | undefined);
+
+  const worldId =
+    (typeof inst.worldId === 'string' ? inst.worldId : '') ||
+    (worldObj && typeof worldObj.id === 'string' ? worldObj.id : '');
+  if (!worldId) return null;
+
+  const worldName =
+    worldObj && typeof worldObj.name === 'string' ? worldObj.name : '';
+
+  return {
+    worldId,
+    worldName,
+    displayName: typeof inst.displayName === 'string' ? inst.displayName : '',
+    name: typeof inst.name === 'string' ? inst.name : '',
+    userCount:
+      typeof inst.userCount === 'number'
+        ? inst.userCount
+        : // n_users は古い/別形式のレスポンスで現れるフィールド名。
+          // どちらで来ても拾えるようフォールバックを用意する。
+          typeof inst.n_users === 'number'
+          ? inst.n_users
+          : 0,
+    capacity: typeof inst.capacity === 'number' ? inst.capacity : 0,
+    region: typeof inst.region === 'string' ? inst.region : '',
+  };
+}
+
+/**
+ * fetchGroupInstances の入力。全て GitHub Secrets から供給する想定。
+ *
+ * - userId / groupId: `usr_...` / `grp_...` 形式の生ID
+ * - authCookie: Cookie 値本体のみ（`auth=` プレフィックスは不要。`authcookie_...` の文字列）
+ * - twoFactorAuthCookie: Cookie 値本体のみ（`twoFactorAuth=` プレフィックスは不要）
+ *   JWT 形式で有効期限 ~30日。期限切れで 401 になったら手動で更新する運用
+ */
+export interface FetchGroupInstancesOptions {
+  userId: string;
+  groupId: string;
+  authCookie: string;
+  twoFactorAuthCookie: string;
+}
+
+/**
+ * VRChat API から指定グループのインスタンス一覧を取得する。
+ *
+ * auth / twoFactorAuth Cookie は GitHub Secrets から渡す。twoFactorAuth は
+ * 有効期限が約 30 日なので、期限切れで 401 になったら手動で更新する運用。
+ */
+export async function fetchGroupInstances(
+  options: FetchGroupInstancesOptions,
+): Promise<GroupInstance[]> {
+  const { userId, groupId, authCookie, twoFactorAuthCookie } = options;
+
+  // Cookie ヘッダ組み立て時にセミコロンが混入すると別の Cookie として解釈される。
+  // Secrets の誤設定や仕様変更を早期検知するため、明示的にガードする。
+  if (authCookie.includes(';') || twoFactorAuthCookie.includes(';')) {
+    throw new Error('Cookie value must not contain ";"');
+  }
+
+  const url = `https://vrchat.com/api/1/users/${encodeURIComponent(userId)}/instances/groups/${encodeURIComponent(groupId)}`;
+
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json',
+      Cookie: `auth=${authCookie}; twoFactorAuth=${twoFactorAuthCookie}`,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `VRChat API failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
+    );
+  }
+
+  const data: unknown = await res.json();
+  if (!Array.isArray(data)) {
+    throw new Error('VRChat API returned non-array response');
+  }
+
+  return data
+    .map(extractInstance)
+    .filter((i): i is GroupInstance => i !== null);
+}
+
+/**
+ * Discord 向けメッセージを組み立てる。
+ *
+ * - 0 件 → "0件でした" を含むメッセージ
+ * - 複数件 → ワールド別にグルーピングし、各インスタンスの人数/定員/リージョンを列挙
+ * - Discord の `<t:UNIX:F>` 記法で閲覧者のローカル時刻として表示
+ *
+ * 呼び出し元: scripts/discord-group-instances-notify.ts
+ */
+export function formatGroupInstancesMessage(
+  instances: GroupInstance[],
+  currentDate: Date = new Date(),
+): string {
+  const unix = Math.floor(currentDate.getTime() / 1000);
+  const header = `🫖 お茶会グループ インスタンス状況 <t:${unix}:F>`;
+
+  if (instances.length === 0) {
+    return `${header}\n\n0件でした`;
+  }
+
+  // ワールドIDでグループ化。Map は挿入順を保持するので API の順序が保たれる
+  const groups = new Map<
+    string,
+    { worldName: string; items: GroupInstance[] }
+  >();
+  for (const inst of instances) {
+    const existing = groups.get(inst.worldId);
+    if (existing) {
+      existing.items.push(inst);
+    } else {
+      groups.set(inst.worldId, {
+        worldName: inst.worldName || inst.worldId,
+        items: [inst],
+      });
+    }
+  }
+
+  const sections: string[] = [];
+  for (const group of groups.values()) {
+    const totalUsers = group.items.reduce((sum, i) => sum + i.userCount, 0);
+    const lines: string[] = [
+      `📍 ${group.worldName} — ${group.items.length} インスタンス / 合計 ${totalUsers} 人`,
+    ];
+    for (const inst of group.items) {
+      const label = inst.displayName || `#${inst.name || '?'}`;
+      const region = inst.region ? ` (${inst.region.toUpperCase()})` : '';
+      lines.push(`• ${label} — ${inst.userCount}/${inst.capacity}${region}`);
+    }
+    sections.push(lines.join('\n'));
+  }
+
+  const full = `${header}\n\n${sections.join('\n\n')}`;
+  return truncateForDiscord(full);
+}
+
+// Discord の `content` は 2000 文字を超えると 400 で拒否される。
+// 超えた場合は黙って切り落とさず省略マーカー付きで渡す。
+// 絵文字（🫖📍• 等）はサロゲートペアを含むため、コードポイント単位で長さを計算する。
+const DISCORD_MAX_CONTENT = 2000;
+const TRUNCATION_SUFFIX = '\n\n…(省略)';
+
+function truncateForDiscord(text: string): string {
+  const codepoints = [...text];
+  if (codepoints.length <= DISCORD_MAX_CONTENT) return text;
+  const suffixLen = [...TRUNCATION_SUFFIX].length;
+  return (
+    codepoints.slice(0, DISCORD_MAX_CONTENT - suffixLen).join('') +
+    TRUNCATION_SUFFIX
+  );
+}


### PR DESCRIPTION
## Summary
- 毎週日曜 15:45 JST に VRChat API からあ茶会グループのインスタンス一覧を取得し、Discord Webhook に投稿する GitHub Actions を追加
- `workflow_dispatch` で任意のタイミングでも実行可能
- ワールド別グルーピング・各インスタンスの人数/定員/リージョン表示・0件時は「0件でした」・Discord 2000文字超過時は省略マーカーで切り詰め

## 必要な GitHub Secrets
- `DISCORD_WEBHOOK_URL` (既存)
- `VRCHAT_USER_ID` — `usr_...` 形式。ボットアカウントのID
- `VRCHAT_GROUP_ID` — `grp_...` 形式
- `VRCHAT_AUTH_COOKIE` — Cookie 値本体 (`authcookie_...`)

※ 実 API での検証により `twoFactorAuth` Cookie は不要と判明したため要件から外しました (30日 JWT の失効管理が不要)。

## メッセージ例 (実 API レスポンスで検証済み)
```
🫖 お茶会グループ インスタンス状況 <t:1776591664:F>

📍 Cuddle ＆ Sleep — 2 インスタンス / 合計 124 人
• Cuddle? — 53/80 (US)
• #55426 — 71/80 (US)
```

## 実装メモ
- fetch URL は `https://api.vrchat.cloud/api/1/...` を直接叩いている (`vrchat.com` 経由だと 307 redirect で Node fetch が Cookie を strip するため)
- レスポンスは `{fetchedAt, instances: [...]}` のラッパー形式を優先し、top-level 配列もフォールバックで受け入れる

## Test plan
- [x] `npx vitest run` 全79件 pass
- [x] `npx biome check .` pass
- [x] code-reviewer によるセルフレビュー計3回実施 (Cookie セミコロンガード / Discord 2000文字制限ガード / 実 API 形式への適合など反映)
- [x] 実 API を叩いて 2インスタンス持つ別グループで正常整形を確認
- [ ] マージ後、GitHub Secrets 設定 → `workflow_dispatch` で手動起動して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)