### PR TITLE
feat: discord-group-instances に workflow_dispatch の group_id 上書き入力を追加

### DIFF
--- a/.github/workflows/discord-group-instances-notify.yml
+++ b/.github/workflows/discord-group-instances-notify.yml
@@ -5,6 +5,11 @@ on:
     # 毎週日曜 15:45 JST (= 06:45 UTC)
     - cron: '45 6 * * 0'
   workflow_dispatch:
+    inputs:
+      group_id:
+        description: '上書きする VRChat Group ID (例: grp_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)。空なら secret VRCHAT_GROUP_ID を使用'
+        required: false
+        type: string
 
 jobs:
   notify:
@@ -27,5 +32,6 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           VRCHAT_USER_ID: ${{ secrets.VRCHAT_USER_ID }}
-          VRCHAT_GROUP_ID: ${{ secrets.VRCHAT_GROUP_ID }}
+          # schedule 実行時は inputs が未定義のため secret にフォールバック
+          VRCHAT_GROUP_ID: ${{ inputs.group_id || secrets.VRCHAT_GROUP_ID }}
           VRCHAT_AUTH_COOKIE: ${{ secrets.VRCHAT_AUTH_COOKIE }}


### PR DESCRIPTION
## Summary
- `workflow_dispatch` の `inputs.group_id` を追加し、手動実行時に任意の VRChat Group ID を指定して通知を飛ばせるようにした
- 空のときは従来どおり `secrets.VRCHAT_GROUP_ID` にフォールバックするため、スケジュール実行（日曜 15:45 JST）と既存の手動実行は無変更で動作する
- `inputs.group_id` は `run:` ではなく `env:` ブロックで受けているため workflow injection のリスクなし

## Test plan
- [ ] GitHub Actions の「Run workflow」から `group_id` を空のまま実行し、従来どおり secret の Group ID で通知が飛ぶこと
- [ ] `group_id` に別グループ（例: `grp_d44312ff-...`）を指定して実行し、そのグループのインスタンスが通知されること
- [ ] 次の日曜の自動実行（schedule）で通知が従来どおり飛ぶこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)