### PR TITLE
feat: twoFactorAuth Cookie 対応と Zod による入力検証

### DIFF
--- a/.github/workflows/discord-group-instances-notify.yml
+++ b/.github/workflows/discord-group-instances-notify.yml
@@ -35,3 +35,7 @@ jobs:
           # schedule 実行時は inputs が未定義のため secret にフォールバック
           VRCHAT_GROUP_ID: ${{ inputs.group_id || secrets.VRCHAT_GROUP_ID }}
           VRCHAT_AUTH_COOKIE: ${{ secrets.VRCHAT_AUTH_COOKIE }}
+          # 任意。auth Cookie 単独だと Cookie 取得元と runner の IP が離れる環境で
+          # 401 "Missing Credentials" が返るため、twoFactorAuth JWT (30 日失効) を
+          # 付与することで IP が変わっても認証が通る (src/lib/fetchGroupInstances.ts 参照)
+          VRCHAT_TWOFA_COOKIE: ${{ secrets.VRCHAT_TWOFA_COOKIE }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -25,7 +26,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3412,6 +3413,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/scripts/discord-group-instances-notify.ts
+++ b/scripts/discord-group-instances-notify.ts
@@ -6,11 +6,13 @@
  *   VRChat API は認証必須のため Cookie を GitHub Secrets から渡す。
  *
  * 実行方法: npx tsx scripts/discord-group-instances-notify.ts
- * 環境変数（全て必須）:
- *   - DISCORD_WEBHOOK_URL
- *   - VRCHAT_USER_ID       (usr_... 形式。bot アカウントの ID)
- *   - VRCHAT_GROUP_ID      (grp_... 形式)
- *   - VRCHAT_AUTH_COOKIE   (authcookie_... の値のみ)
+ * 環境変数:
+ *   - DISCORD_WEBHOOK_URL  (必須)
+ *   - VRCHAT_USER_ID       (必須。usr_... 形式、bot アカウントの ID)
+ *   - VRCHAT_GROUP_ID      (必須。grp_... 形式)
+ *   - VRCHAT_AUTH_COOKIE   (必須。authcookie_... の値本体のみ)
+ *   - VRCHAT_TWOFA_COOKIE  (任意。twoFactorAuth Cookie の JWT 値。
+ *     Cookie 取得元と叩く IP が離れる環境では付けないと 401 になる)
  */
 
 import {
@@ -32,12 +34,16 @@ async function main() {
   const userId = requireEnv('VRCHAT_USER_ID');
   const groupId = requireEnv('VRCHAT_GROUP_ID');
   const authCookie = requireEnv('VRCHAT_AUTH_COOKIE');
+  // 未設定 secret は `''` に展開される。fetchGroupInstances のスキーマは
+  // 空文字列を「未指定扱い」として受け入れるため、そのまま渡してよい。
+  const twoFactorAuthCookie = process.env.VRCHAT_TWOFA_COOKIE ?? '';
 
   console.log('VRChat グループインスタンス一覧を取得中...');
   const instances = await fetchGroupInstances({
     userId,
     groupId,
     authCookie,
+    twoFactorAuthCookie,
   });
   console.log(`${instances.length} 件のインスタンスを取得`);
 

--- a/src/lib/fetchGroupInstances.test.ts
+++ b/src/lib/fetchGroupInstances.test.ts
@@ -16,11 +16,14 @@ describe('fetchGroupInstances', () => {
     globalThis.fetch = originalFetch;
   });
 
+  // Zod スキーマが usr_/grp_/authcookie_ + UUID(8-4-4-4-12 hex) の形式を要求するため、
+  // テストでも有効な UUID 形式のダミー値を使用する。
   const baseOptions = {
-    userId: 'usr_abc',
-    groupId: 'grp_xyz',
-    authCookie: 'authcookie_val',
+    userId: 'usr_abcdef01-2345-6789-abcd-ef0123456789',
+    groupId: 'grp_abcdef01-2345-6789-abcd-ef0123456789',
+    authCookie: 'authcookie_abcdef01-2345-6789-abcd-ef0123456789',
   };
+  const AUTH_COOKIE_HEADER = `auth=${baseOptions.authCookie}`;
 
   // 実 API のレスポンス形状を再現した mock helper。
   // 2026-04 時点で VRChat API が返す top-level は `{fetchedAt, instances: [...]}`
@@ -56,10 +59,10 @@ describe('fetchGroupInstances', () => {
     const result = await fetchGroupInstances(baseOptions);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.vrchat.cloud/api/1/users/usr_abc/instances/groups/grp_xyz',
+      `https://api.vrchat.cloud/api/1/users/${baseOptions.userId}/instances/groups/${baseOptions.groupId}`,
       expect.objectContaining({
         headers: expect.objectContaining({
-          Cookie: 'auth=authcookie_val',
+          Cookie: AUTH_COOKIE_HEADER,
         }),
       }),
     );
@@ -125,11 +128,150 @@ describe('fetchGroupInstances', () => {
     expect(result[0].worldId).toBe('wrld_legacy');
   });
 
-  it('Cookie 値にセミコロンが含まれていたら例外を投げる', async () => {
+  it('userId が VRChat の形式でなければ fetch 前にスキーマエラーを投げる', async () => {
+    await expect(
+      fetchGroupInstances({ ...baseOptions, userId: 'usr_abc' }),
+    ).rejects.toThrow(/Invalid fetchGroupInstances options.*userId/);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it('groupId が VRChat の形式でなければ fetch 前にスキーマエラーを投げる', async () => {
+    await expect(
+      fetchGroupInstances({ ...baseOptions, groupId: 'grp_xyz' }),
+    ).rejects.toThrow(/Invalid fetchGroupInstances options.*groupId/);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it('authCookie が authcookie_<uuid> 形式でなければ fetch 前にスキーマエラーを投げる', async () => {
     await expect(
       fetchGroupInstances({ ...baseOptions, authCookie: 'bad;value' }),
-    ).rejects.toThrow(/Cookie value must not contain/);
-    // セミコロンチェックは fetch 前で行う
+    ).rejects.toThrow(/Invalid fetchGroupInstances options.*authCookie/);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  // Cookie の値本体だけを登録する運用のため、`auth=` を含めて登録する
+  // よくある設定ミスをスキーマ段階で弾けることを保証する
+  it('authCookie に "auth=" プレフィックスが含まれていたら fetch 前にスキーマエラーを投げる', async () => {
+    await expect(
+      fetchGroupInstances({
+        ...baseOptions,
+        authCookie: `auth=${baseOptions.authCookie}`,
+      }),
+    ).rejects.toThrow(/Invalid fetchGroupInstances options.*authCookie/);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  // prefix ごとスキーマを分けているので、userId と groupId を取り違えた secret 登録は
+  // runtime Zod で弾かれる（branded types の代替として働く）
+  it('userId に grp_ プレフィックスの値を渡すと fetch 前にスキーマエラーを投げる', async () => {
+    await expect(
+      fetchGroupInstances({
+        ...baseOptions,
+        userId: baseOptions.groupId,
+      }),
+    ).rejects.toThrow(/Invalid fetchGroupInstances options.*userId/);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it('groupId に usr_ プレフィックスの値を渡すと fetch 前にスキーマエラーを投げる', async () => {
+    await expect(
+      fetchGroupInstances({
+        ...baseOptions,
+        groupId: baseOptions.userId,
+      }),
+    ).rejects.toThrow(/Invalid fetchGroupInstances options.*groupId/);
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  it('twoFactorAuthCookie を JWT で渡すと Cookie ヘッダに併送される', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(realResponse([])), { status: 200 }),
+    );
+
+    const jwt = 'aGVhZGVy.cGF5bG9hZA.c2ln';
+    await fetchGroupInstances({
+      ...baseOptions,
+      twoFactorAuthCookie: jwt,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: `${AUTH_COOKIE_HEADER}; twoFactorAuth=${jwt}`,
+        }),
+      }),
+    );
+  });
+
+  // ブラウザから Cookie をコピーしてくると base64url の末尾 `=` パディングが
+  // 混入するケースがある。regex が `=*` で許容することを契約として固定しておく。
+  it('twoFactorAuthCookie の各セグメントに = パディングがあっても許容する', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(realResponse([])), { status: 200 }),
+    );
+
+    const paddedJwt = 'aGVhZGVy==.cGF5bG9hZA==.c2ln==';
+    await fetchGroupInstances({
+      ...baseOptions,
+      twoFactorAuthCookie: paddedJwt,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: `${AUTH_COOKIE_HEADER}; twoFactorAuth=${paddedJwt}`,
+        }),
+      }),
+    );
+  });
+
+  it('twoFactorAuthCookie が未指定なら auth のみ送る', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(realResponse([])), { status: 200 }),
+    );
+
+    await fetchGroupInstances(baseOptions);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: AUTH_COOKIE_HEADER,
+        }),
+      }),
+    );
+  });
+
+  it('twoFactorAuthCookie が空文字列なら auth のみ送る（未設定 secret の展開値を許容）', async () => {
+    const mockFetch = vi.mocked(globalThis.fetch);
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(realResponse([])), { status: 200 }),
+    );
+
+    await fetchGroupInstances({ ...baseOptions, twoFactorAuthCookie: '' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Cookie: AUTH_COOKIE_HEADER }),
+      }),
+    );
+  });
+
+  it('twoFactorAuthCookie が JWT 形式でなければ fetch 前にスキーマエラーを投げる', async () => {
+    await expect(
+      fetchGroupInstances({
+        ...baseOptions,
+        twoFactorAuthCookie: 'bad;jwt',
+      }),
+    ).rejects.toThrow(
+      /Invalid fetchGroupInstances options.*twoFactorAuthCookie/,
+    );
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
   });
 
@@ -172,24 +314,6 @@ describe('fetchGroupInstances', () => {
 
     await expect(fetchGroupInstances(baseOptions)).rejects.toThrow(
       /unexpected response shape/,
-    );
-  });
-
-  it('ユーザーID・グループIDを URL エンコードする', async () => {
-    const mockFetch = vi.mocked(globalThis.fetch);
-    mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify(realResponse([])), { status: 200 }),
-    );
-
-    await fetchGroupInstances({
-      ...baseOptions,
-      userId: 'usr a/b',
-      groupId: 'grp x',
-    });
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.vrchat.cloud/api/1/users/usr%20a%2Fb/instances/groups/grp%20x',
-      expect.any(Object),
     );
   });
 });

--- a/src/lib/fetchGroupInstances.ts
+++ b/src/lib/fetchGroupInstances.ts
@@ -11,8 +11,42 @@
  * 呼び出し元: scripts/discord-group-instances-notify.ts (GitHub Actions)
  */
 
+import { z } from 'zod';
+
 const USER_AGENT =
   'tweet-validator-for-achakai/1.0 (+https://github.com/tktcorporation/tweet-validator-for-achakai)';
+
+// VRChat の識別子は `<prefix>_<UUID>` の形式で、UUID は 8-4-4-4-12 の hex。
+// 非公式 API のため将来変わる可能性はあるが、2026-04 現在この形式で統一されている。
+// Zod schema で形式を縛ることで、誤った Secrets を登録したときに fetch 前に検知する。
+const UUID_HEX =
+  '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+const VRChatUserIdSchema = z
+  .string()
+  .regex(new RegExp(`^usr_${UUID_HEX}$`), 'userId must be usr_<uuid>');
+
+const VRChatGroupIdSchema = z
+  .string()
+  .regex(new RegExp(`^grp_${UUID_HEX}$`), 'groupId must be grp_<uuid>');
+
+const VRChatAuthCookieSchema = z
+  .string()
+  .regex(
+    new RegExp(`^authcookie_${UUID_HEX}$`),
+    'authCookie must be authcookie_<uuid> (raw value only, no "auth=" prefix)',
+  );
+
+// twoFactorAuth Cookie は VRChat が発行する JWT。
+// base64url 文字 + `.` 2 つで構成される 3 セグメント形式を許容する。
+// 各セグメントの末尾 `=` パディングは RFC 7515 では禁止だが、
+// ブラウザから値をコピーしてくる経路で紛れ込む可能性があるので通す。
+const JwtSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z0-9_-]+=*\.[A-Za-z0-9_-]+=*\.[A-Za-z0-9_-]+=*$/,
+    'twoFactorAuthCookie must be a JWT (three base64url segments separated by ".")',
+  );
 
 /**
  * 整形処理で利用する最小限のインスタンス情報。
@@ -75,20 +109,32 @@ function extractInstance(raw: unknown): GroupInstance | null {
 }
 
 /**
- * fetchGroupInstances の入力。全て GitHub Secrets から供給する想定。
+ * fetchGroupInstances の入力スキーマ。全て GitHub Secrets から供給する想定。
  *
- * - userId / groupId: `usr_...` / `grp_...` 形式の生ID
- * - authCookie: Cookie 値本体のみ（`auth=` プレフィックスは不要。`authcookie_...` の文字列）
+ * - userId / groupId: `usr_<uuid>` / `grp_<uuid>` の VRChat 識別子
+ * - authCookie: `auth` Cookie の値本体（`authcookie_<uuid>`。`auth=` プレフィックス不要）
+ * - twoFactorAuthCookie (任意): `twoFactorAuth` Cookie の JWT 値。
+ *   空文字列は未指定と同義で Cookie ヘッダに追加しない
+ *   （GitHub Actions の未設定 secret は `''` に展開されるため）
  *
- * 実験により、この endpoint は `auth` Cookie 単独で 200 を返すことを確認済み。
- * `twoFactorAuth` Cookie は付けても付けなくてもレスポンスが変わらないため、
- * 運用を単純化するため要求しない（30日失効 JWT の管理を避ける）。
+ * `twoFactorAuth` Cookie は運用上付けることを推奨する。
+ * 同一 IP から叩く限りは `auth` 単独でも 200 が返るが、GitHub Actions runner
+ * のように Cookie 取得元と IP が大きく離れた環境では `auth` 単独で
+ * "Missing Credentials" (401) が返るケースを確認している。
+ * JWT (30 日失効) を付与すると IP が変わっても検証に通る。
  */
-export interface FetchGroupInstancesOptions {
-  userId: string;
-  groupId: string;
-  authCookie: string;
-}
+export const FetchGroupInstancesOptionsSchema = z.object({
+  userId: VRChatUserIdSchema,
+  groupId: VRChatGroupIdSchema,
+  authCookie: VRChatAuthCookieSchema,
+  // z.literal('') を union に含めることで「未設定 secret が '' で渡る」ケースを
+  // 型の上で明示的に許容する。呼び出し側で `|| undefined` 変換しなくてもよい。
+  twoFactorAuthCookie: z.union([JwtSchema, z.literal('')]).optional(),
+});
+
+export type FetchGroupInstancesOptions = z.infer<
+  typeof FetchGroupInstancesOptionsSchema
+>;
 
 /**
  * VRChat API から指定グループのインスタンス一覧を取得する。
@@ -99,12 +145,20 @@ export interface FetchGroupInstancesOptions {
 export async function fetchGroupInstances(
   options: FetchGroupInstancesOptions,
 ): Promise<GroupInstance[]> {
-  const { userId, groupId, authCookie } = options;
+  // Parse, Don't Validate: 誤った Secrets を登録すると fetch 前に具体的な
+  // フィールド名付きで失敗するので、401/400 と比べて切り分けが容易になる。
+  const parsed = FetchGroupInstancesOptionsSchema.safeParse(options);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    throw new Error(`Invalid fetchGroupInstances options: ${issues}`);
+  }
+  const { userId, groupId, authCookie, twoFactorAuthCookie } = parsed.data;
 
-  // Cookie ヘッダ組み立て時にセミコロンが混入すると別の Cookie として解釈される。
-  // Secrets の誤設定や仕様変更を早期検知するため、明示的にガードする。
-  if (authCookie.includes(';')) {
-    throw new Error('Cookie value must not contain ";"');
+  const cookieParts = [`auth=${authCookie}`];
+  if (twoFactorAuthCookie) {
+    cookieParts.push(`twoFactorAuth=${twoFactorAuthCookie}`);
   }
 
   // vrchat.com は api.vrchat.cloud へ 307 リダイレクトする。
@@ -116,7 +170,7 @@ export async function fetchGroupInstances(
     headers: {
       'User-Agent': USER_AGENT,
       Accept: 'application/json',
-      Cookie: `auth=${authCookie}`,
+      Cookie: cookieParts.join('; '),
     },
   });
 


### PR DESCRIPTION
## Summary
- `twoFactorAuth` Cookie (JWT) を併送できるように `fetchGroupInstances` を拡張。GitHub Actions runner の IP が Cookie 取得元と離れる環境で `auth` 単独だと 401 になるため、30 日失効の JWT を付与すると IP 変化でも認証が通る
- `userId` / `groupId` / `authCookie` / `twoFactorAuthCookie` を **Zod** で fetch 前に検証（Parse, Don't Validate）。誤った Secrets 設定時に具体的なフィールド名付きエラーで即時失敗する
- `.github/workflows/discord-group-instances-notify.yml` に `VRCHAT_TWOFA_COOKIE` 環境変数を追加（任意）

## 背景

本日 #51 をマージ後に `workflow_dispatch` で叩いたら 401 "Missing Credentials" が返り続けた。Codespace（同一 IP）から叩くと 200、GitHub Actions runner（別 IP）からだと 401 という挙動で、VRChat 側が auth Cookie を IP にバインドしている可能性が高い。`twoFactorAuth` JWT を併送すれば IP 変化で通ることが確認できたため、対応。

## スキーマ設計

- `VRChatUserIdSchema`: `/^usr_<UUID>$/`
- `VRChatGroupIdSchema`: `/^grp_<UUID>$/`
- `VRChatAuthCookieSchema`: `/^authcookie_<UUID>$/` (`auth=` プレフィックス不要、値本体のみ)
- `JwtSchema`: 3 base64url セグメント + 各セグメント末尾 `=` padding 許容（ブラウザコピー経路対応）
- `twoFactorAuthCookie` は `z.union([JwtSchema, z.literal('')]).optional()` で未設定 secret の `''` を型レベルで明示許容

## セルフレビュー結果

### 修正した指摘
- JWT regex が `=` padding を拒否 → `=*` 許容に緩和 + WHY コメント追加
- workflow YAML の `VRCHAT_TWOFA_COOKIE` に WHY コメント追加
- 追加テスト 4 件: `auth=` プレフィックス誤設定 / `userId ↔ groupId` 取り違え（両方向）/ padding 付き JWT

### 見つけたが修正しなかったもの
- **Branded types の導入**: 呼び出し箇所が `scripts/discord-group-instances-notify.ts` の 1 箇所のみで、runtime Zod で prefix swap が弾ける構造になっているため見送り
- **JWT regex の `+` セグメント最小1文字要件コメント**: 既存コメント「3 セグメント形式」で伝達可能、追加コメントは自明性の範囲
- **`encodeURIComponent` の冗長性**: Zod 検証後は実質 no-op だが、防衛的実装として残す

## Test plan
- [x] `npx biome check .` pass
- [x] `npx vitest run` pass (88 tests)
- [ ] マージ後、GitHub Actions で `VRCHAT_TWOFA_COOKIE` secret を登録し、`workflow_dispatch` の手動実行が 200 で通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)