### PR TITLE
Discord週次通知の実行を火曜20時(JST)に変更

### DIFF
--- a/.github/workflows/discord-weekly-notify.yml
+++ b/.github/workflows/discord-weekly-notify.yml
@@ -2,8 +2,8 @@ name: Discord Weekly Notify
 
 on:
   schedule:
-    # 毎週水曜 20:00 JST (= 11:00 UTC)
-    - cron: '0 11 * * 3'
+    # 毎週火曜 20:00 JST (= 11:00 UTC)
+    - cron: '0 11 * * 2'
   workflow_dispatch:
 
 jobs:

--- a/scripts/discord-weekly-notify.ts
+++ b/scripts/discord-weekly-notify.ts
@@ -1,7 +1,7 @@
 /**
  * Discord 週次お茶会通知スクリプト。
  *
- * 背景: 毎週水曜20時(JST)に今週の日曜のお茶会予定を Discord に通知する。
+ * 背景: 毎週火曜20時(JST)に今週の日曜のお茶会予定を Discord に通知する。
  * スプレッドシートの確定チェック状態に応じてメッセージを出し分ける。
  *
  * 実行方法: npx tsx scripts/discord-weekly-notify.ts

--- a/src/lib/fetchSheetSchedule.ts
+++ b/src/lib/fetchSheetSchedule.ts
@@ -186,7 +186,7 @@ export function deriveSkippedDates(entries: ScheduleEntry[]): Date[] {
 }
 
 /**
- * 水曜日の Discord 週次通知用メッセージを生成する。
+ * 火曜日の Discord 週次通知用メッセージを生成する。
  * currentDate から直近の日曜を求め、該当エントリの状態に応じてメッセージを返す。
  *
  * 呼び出し元: scripts/discord-weekly-notify.ts (GitHub Actions から実行)


### PR DESCRIPTION
## Summary
- `discord-weekly-notify.yml` の cron を毎週水曜20:00 JST (`0 11 * * 3`) から毎週火曜20:00 JST (`0 11 * * 2`) に変更
- 関連するコメント・JSDoc（`scripts/discord-weekly-notify.ts`、`src/lib/fetchSheetSchedule.ts`）を火曜表記に更新

対象週の判定に使う `getUpcomingSunday` は実行日から直近の日曜を計算する汎用ロジックのため、実行曜日を変えても通知対象の日曜はずれません。

## Test plan
- [x] `npx biome check .`
- [x] `npx biome format .`
- [x] `npm run typecheck`
- [x] `npx vitest run`（110件 pass）

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAdqcHzZuPRn6yxe4krJQE)_