### PR TITLE
fix: 末尾URLを含むツイートの文字数カウントをX仕様に合わせる

### DIFF
--- a/src/hooks/useTweetState.test.ts
+++ b/src/hooks/useTweetState.test.ts
@@ -77,6 +77,38 @@ describe('countTweetLength', () => {
   it('returns 0 for an empty string', () => {
     expect(countTweetLength('')).toBe(0);
   });
+
+  it('counts a short URL as the fixed t.co length of 23', () => {
+    expect(countTweetLength('https://t.co/a')).toBe(23);
+  });
+
+  it('counts a long URL as the fixed t.co length of 23', () => {
+    const longUrl =
+      'https://example.com/very/long/path/that/exceeds/twenty-three/characters';
+    expect(countTweetLength(longUrl)).toBe(23);
+  });
+
+  it('counts an http (non-https) URL as the fixed t.co length of 23', () => {
+    expect(countTweetLength('http://example.com')).toBe(23);
+  });
+
+  it('counts a URL at the end of the tweet together with the preceding text', () => {
+    const text = '本文\n\nhttps://vrchat.com/home/world/wrld_1234';
+    // 「本文」(2 * 2) + 改行2文字 (1 * 2) + URL固定長23
+    expect(countTweetLength(text)).toBe(4 + 2 + 23);
+  });
+
+  it('counts each URL separately when multiple URLs are present', () => {
+    const text = 'https://example.com/one https://example.com/two';
+    // URL x2 (23 * 2) + 区切りの半角スペース1文字
+    expect(countTweetLength(text)).toBe(23 * 2 + 1);
+  });
+
+  it('does not swallow Japanese text directly following a URL with no space', () => {
+    const text = '詳細はhttps://example.comをご覧ください';
+    // 「詳細は」(3 * 2) + URL固定長23 + 「をご覧ください」(7 * 2)
+    expect(countTweetLength(text)).toBe(6 + 23 + 14);
+  });
 });
 
 describe('buildStructuredTweet', () => {

--- a/src/hooks/useTweetState.ts
+++ b/src/hooks/useTweetState.ts
@@ -28,11 +28,25 @@ const STORAGE_KEY = 'tweet-state';
 export const instrumentEmojiArray =
   '🎸 🎹 🥁 🎺 🎻 🎷 🪕 🪗 🎤 🎧 📯 🪘 🎼'.split(' ');
 
+/**
+ * X (Twitter) は投稿中のURLを t.co 経由で全て固定長に短縮するため、
+ * URL部分は実際の文字数ではなくこの固定値でカウントされる
+ * （元のURLがこれより短くても23として数えられる）。
+ */
+const SHORTENED_URL_LENGTH = 23;
+
 export function countTweetLength(text: string): number {
   const wideChar =
     /[\u1100-\u115F\u2329\u232A\u2E80-\uA4CF\uAC00-\uD7A3\uF900-\uFAFF\uFE10-\uFE19\uFE30-\uFE6F\uFF00-\uFF60\uFFE0-\uFFE6]/u;
-  let count = 0;
-  for (const ch of [...text]) {
+  // URLに使われうるASCII文字だけにマッチさせる。\S+ だと空白なしで
+  // 後続する日本語（例: 「https://example.comをご覧ください」の「をご覧ください」）
+  // までURLとして飲み込んでしまい、本来カウントすべき文字が消える。
+  const urlPattern = /https?:\/\/[\w\-._~:/?#[\]@!$&'()*+,;=%]+/g;
+  const urls = text.match(urlPattern) ?? [];
+  const textWithoutUrls = text.replace(urlPattern, '');
+
+  let count = urls.length * SHORTENED_URL_LENGTH;
+  for (const ch of [...textWithoutUrls]) {
     count += wideChar.test(ch) ? 2 : 1;
   }
   return count;


### PR DESCRIPTION
## Summary
- X (Twitter) はツイート内のURLをt.co経由で全て固定23文字としてカウントするが、`countTweetLength`（`src/hooks/useTweetState.ts`）はURLの実際の文字数をそのまま数えていたため、末尾にVRChatワールドURLを付与すると画面上の文字数表示と実際の投稿可否がずれていた。
- URL (http/https) を検出し、実際の長さに関わらず固定23文字としてカウントするよう修正。URLに空白なしで後続テキストが直接続く場合（例: 日本語が直後に続くケース）でも、URL部分だけを正しく切り出して数える。

## Test plan
- [x] `npx vitest run`
- [x] `npx biome check .`
- [x] `npx biome format .`
- [x] `npm run typecheck`

---
_Generated by [Claude Code](https://claude.ai/code/session_019dh5dG8xor1Bc1TkysDv6V)_